### PR TITLE
feat: support native file drop attachments

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -28,7 +28,7 @@
     ],
     "macOSPrivateApi": true,
     "security": {
-      "csp": "default-src 'self' ipc: http://ipc.localhost; img-src 'self' data: asset: http://asset.localhost https:; style-src 'self' 'unsafe-inline'; connect-src ipc: http://ipc.localhost",
+      "csp": "default-src 'self' ipc: http://ipc.localhost; img-src 'self' data: asset: http://asset.localhost https:; style-src 'self' 'unsafe-inline'; connect-src ipc: http://ipc.localhost asset: http://asset.localhost",
       "assetProtocol": {
         "enable": true,
         "scope": [

--- a/src/app/AppRoot.tsx
+++ b/src/app/AppRoot.tsx
@@ -1,9 +1,52 @@
-import { lazy, Suspense } from 'react';
+import { lazy, Suspense, useEffect } from 'react';
 import DeferredSurface from '../components/DeferredSurface';
-import { isStandaloneComposerWindow } from '../tauriBridge';
+import { emptyDraft } from './appConfig';
+import { importNativeDroppedAttachmentPaths } from './nativeDroppedAttachments';
+import {
+  getCurrentWindow,
+  isStandaloneComposerWindow,
+  mockMode,
+  openComposerWindow,
+} from '../tauriBridge';
 
 const MailboxApp = lazy(() => import('../App'));
 const StandaloneComposerApp = lazy(() => import('../components/StandaloneComposerApp'));
+
+function MainWindowFileDropBridge() {
+  useEffect(() => {
+    if (mockMode) return undefined;
+    let active = true;
+    let unlisten: (() => void) | undefined;
+
+    void getCurrentWindow().onDragDropEvent(async (event) => {
+      if (!active || event.type !== 'drop') return;
+      const paths = event.paths.filter((path) => path.trim());
+      if (paths.length === 0) return;
+
+      const result = await importNativeDroppedAttachmentPaths(paths);
+      if (!active || result.attachments.length === 0) return;
+
+      await openComposerWindow({
+        draft: {
+          ...emptyDraft,
+          attachments: result.attachments,
+        },
+        replaceExisting: true,
+      });
+    })
+      .then((nextUnlisten) => {
+        unlisten = nextUnlisten;
+      })
+      .catch(() => undefined);
+
+    return () => {
+      active = false;
+      unlisten?.();
+    };
+  }, []);
+
+  return null;
+}
 
 /**
  * Application entry boundary.
@@ -16,14 +59,17 @@ export default function AppRoot() {
   const Surface = standaloneComposer ? StandaloneComposerApp : MailboxApp;
 
   return (
-    <Suspense
-      fallback={(
-        <DeferredSurface
-          label={standaloneComposer ? '正在准备写信窗口' : '正在准备邮箱工作区'}
-        />
-      )}
-    >
-      <Surface />
-    </Suspense>
+    <>
+      {!standaloneComposer ? <MainWindowFileDropBridge /> : null}
+      <Suspense
+        fallback={(
+          <DeferredSurface
+            label={standaloneComposer ? '正在准备写信窗口' : '正在准备邮箱工作区'}
+          />
+        )}
+      >
+        <Surface />
+      </Suspense>
+    </>
   );
 }

--- a/src/app/AppRoot.tsx
+++ b/src/app/AppRoot.tsx
@@ -1,6 +1,7 @@
 import { lazy, Suspense, useEffect } from 'react';
 import DeferredSurface from '../components/DeferredSurface';
 import { emptyDraft } from './appConfig';
+import { logError } from './logger';
 import { importNativeDroppedAttachmentPaths } from './nativeDroppedAttachments';
 import {
   getCurrentWindow,
@@ -18,26 +19,41 @@ function MainWindowFileDropBridge() {
     let active = true;
     let unlisten: (() => void) | undefined;
 
-    void getCurrentWindow().onDragDropEvent(async (event) => {
+    void getCurrentWindow().onDragDropEvent((event) => {
       if (!active || event.type !== 'drop') return;
       const paths = event.paths.filter((path) => path.trim());
       if (paths.length === 0) return;
 
-      const result = await importNativeDroppedAttachmentPaths(paths);
-      if (!active || result.attachments.length === 0) return;
+      void (async () => {
+        try {
+          const result = await importNativeDroppedAttachmentPaths(paths);
+          if (!active) return;
+          if (result.failed > 0) {
+            logError('Main-window native file drop partially failed', {
+              failed: result.failed,
+              firstError: result.firstError,
+            });
+          }
+          if (result.attachments.length === 0) return;
 
-      await openComposerWindow({
-        draft: {
-          ...emptyDraft,
-          attachments: result.attachments,
-        },
-        replaceExisting: true,
-      });
+          await openComposerWindow({
+            draft: {
+              ...emptyDraft,
+              attachments: result.attachments,
+            },
+            replaceExisting: true,
+          });
+        } catch (error) {
+          logError('Main-window native file drop failed', error);
+        }
+      })();
     })
       .then((nextUnlisten) => {
         unlisten = nextUnlisten;
       })
-      .catch(() => undefined);
+      .catch((error) => {
+        logError('Main-window native drag/drop listener unavailable', error);
+      });
 
     return () => {
       active = false;

--- a/src/app/nativeDroppedAttachments.test.ts
+++ b/src/app/nativeDroppedAttachments.test.ts
@@ -1,0 +1,68 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { IPC } from '../ipc/commands';
+import { importNativeDroppedAttachmentPaths } from './nativeDroppedAttachments';
+
+const bridgeMocks = vi.hoisted(() => ({
+  invoke: vi.fn(),
+  localFileAssetUrl: vi.fn(),
+}));
+
+vi.mock('../tauriBridge', () => ({
+  invoke: bridgeMocks.invoke,
+  localFileAssetUrl: bridgeMocks.localFileAssetUrl,
+}));
+
+describe('importNativeDroppedAttachmentPaths', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    bridgeMocks.localFileAssetUrl.mockImplementation(async (path: string) => `asset://${path}`);
+    bridgeMocks.invoke.mockResolvedValue('/private/temp/attachment');
+  });
+
+  it('imports a native dropped path directly through the scoped asset URL', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      blob: async () => new Blob(['hello'], { type: 'text/plain' }),
+    })));
+
+    const result = await importNativeDroppedAttachmentPaths(['C:\\Users\\me\\hello.txt']);
+
+    expect(result.failed).toBe(0);
+    expect(result.attachments).toEqual([
+      expect.objectContaining({
+        filename: 'hello.txt',
+        mime_type: 'text/plain',
+        size_bytes: 5,
+        local_path: '/private/temp/attachment',
+      }),
+    ]);
+    expect(bridgeMocks.invoke).toHaveBeenCalledWith(
+      IPC.SaveTempAttachment,
+      expect.objectContaining({ filename: 'hello.txt' }),
+    );
+    expect(bridgeMocks.invoke).not.toHaveBeenCalledWith(IPC.PickOutboundAttachments, expect.anything());
+  });
+
+  it('keeps successful files when another dropped file fails', async () => {
+    vi.stubGlobal('fetch', vi.fn(async (url: string) => {
+      if (url.includes('bad.pdf')) throw new Error('blocked');
+      return {
+        ok: true,
+        status: 200,
+        blob: async () => new Blob(['ok'], { type: 'text/plain' }),
+      };
+    }));
+
+    const result = await importNativeDroppedAttachmentPaths([
+      '/tmp/good.txt',
+      '/tmp/bad.pdf',
+      '/tmp/good.txt',
+    ]);
+
+    expect(result.attachments).toHaveLength(1);
+    expect(result.failed).toBe(1);
+    expect(result.firstError).toContain('blocked');
+    expect(bridgeMocks.localFileAssetUrl).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/app/nativeDroppedAttachments.ts
+++ b/src/app/nativeDroppedAttachments.ts
@@ -1,0 +1,76 @@
+import type { OutboundAttachmentInput } from './types';
+import { invoke, localFileAssetUrl } from '../tauriBridge';
+import { IPC } from '../ipc/commands';
+
+export type NativeDroppedAttachmentImportResult = {
+  attachments: OutboundAttachmentInput[];
+  failed: number;
+  firstError: string | null;
+};
+
+function filenameFromNativePath(path: string) {
+  const normalized = path.trim().replace(/[\\/]+$/, '');
+  const parts = normalized.split(/[\\/]/);
+  return parts[parts.length - 1] || 'attachment';
+}
+
+function readBlobAsBase64(blob: Blob) {
+  return new Promise<string>((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => {
+      const result = typeof reader.result === 'string' ? reader.result : '';
+      resolve(result.split(',')[1] || '');
+    };
+    reader.onerror = () => reject(new Error('读取拖入文件失败'));
+    reader.readAsDataURL(blob);
+  });
+}
+
+/**
+ * Import paths received directly from Tauri's native drag/drop event.
+ *
+ * Tauri adds real OS-dropped paths to the asset-protocol scope before the
+ * renderer receives the drag event. We only read those scoped asset URLs and
+ * immediately persist them through SaveTempAttachment, so arbitrary renderer
+ * paths never become a privileged path-based IPC surface.
+ */
+export async function importNativeDroppedAttachmentPaths(
+  paths: string[],
+  onProgress?: (completed: number, total: number) => void,
+): Promise<NativeDroppedAttachmentImportResult> {
+  const uniquePaths = [...new Set(paths.map((path) => path.trim()).filter(Boolean))];
+  const attachments: OutboundAttachmentInput[] = [];
+  let failed = 0;
+  let firstError: string | null = null;
+
+  onProgress?.(0, uniquePaths.length);
+  for (const [index, path] of uniquePaths.entries()) {
+    try {
+      const assetUrl = await localFileAssetUrl(path);
+      const response = await fetch(assetUrl);
+      if (!response.ok) {
+        throw new Error(`无法读取拖入文件（${response.status}）`);
+      }
+      const blob = await response.blob();
+      const filename = filenameFromNativePath(path);
+      const base64Data = await readBlobAsBase64(blob);
+      const savedPath = await invoke<string>(IPC.SaveTempAttachment, {
+        filename,
+        base64Data,
+      });
+      attachments.push({
+        filename,
+        mime_type: blob.type || 'application/octet-stream',
+        size_bytes: Math.min(blob.size, Number.MAX_SAFE_INTEGER),
+        local_path: savedPath,
+      });
+    } catch (error) {
+      failed += 1;
+      firstError ??= String(error);
+    } finally {
+      onProgress?.(index + 1, uniquePaths.length);
+    }
+  }
+
+  return { attachments, failed, firstError };
+}

--- a/src/hooks/useComposerAttachments.ts
+++ b/src/hooks/useComposerAttachments.ts
@@ -3,6 +3,7 @@ import type { OutboundAttachmentInput } from '../app/types';
 import { getCurrentWindow, invoke } from '../tauriBridge';
 import { IPC } from '../ipc/commands';
 import { logError } from '../app/logger';
+import { importNativeDroppedAttachmentPaths } from '../app/nativeDroppedAttachments';
 
 type ComposerAttachmentsOptions = {
   isComposerOpen: boolean;
@@ -37,50 +38,6 @@ export default function useComposerAttachments({
 }: ComposerAttachmentsOptions) {
   const [isComposerDropActive, setComposerDropActive] = useState(false);
 
-  useEffect(() => {
-    if (!isComposerOpen) return undefined;
-    let active = true;
-    let unlisten: (() => void) | undefined;
-
-    getCurrentWindow().onDragDropEvent(async (event) => {
-      if (!active) return;
-      if (event.type === 'enter' || event.type === 'over') {
-        setComposerDropActive(true);
-        return;
-      }
-      if (event.type === 'leave') {
-        setComposerDropActive(false);
-        return;
-      }
-      setComposerDropActive(false);
-      const paths = event.paths.filter((path) => path.trim());
-      if (paths.length === 0) {
-        setStatus('拖拽内容中没有文件');
-        return;
-      }
-      // 操作系统拖放只暴露路径，renderer 可伪造任意路径，后端不能据此授权文件。
-      // 因此 OS 拖放不再走路径 IPC（outbound_attachments_from_paths 已移除），
-      // 回退到原生文件选择器流程（由后端登记具体文件）。
-      // HTML5 拖放 / 粘贴（File 对象）仍走 save_temp_attachment，由后端写私有临时文件。
-      setStatus('已捕获系统拖放文件，请通过「选择附件」选择要附加的文件');
-      void pickDraftAttachments().catch((error) => {
-        setStatus(`附件选择失败：${String(error)}`);
-      });
-    })
-      .then((nextUnlisten) => {
-        unlisten = nextUnlisten;
-      })
-      .catch((error) => {
-        setStatus(`附件拖拽不可用：${String(error)}`);
-      });
-
-    return () => {
-      active = false;
-      setComposerDropActive(false);
-      unlisten?.();
-    };
-  }, [isComposerOpen, onAttachmentsReady]);
-
   function setDropActive(next: boolean) {
     setComposerDropActive(next);
   }
@@ -98,6 +55,63 @@ export default function useComposerAttachments({
   function clearAttachmentProgress() {
     setAttachmentProgress?.(null);
   }
+
+  useEffect(() => {
+    if (!isComposerOpen) return undefined;
+    let active = true;
+    let unlisten: (() => void) | undefined;
+
+    getCurrentWindow().onDragDropEvent(async (event) => {
+      if (!active) return;
+      if (event.type === 'enter' || event.type === 'over') {
+        setComposerDropActive(true);
+        return;
+      }
+      if (event.type === 'leave') {
+        setComposerDropActive(false);
+        return;
+      }
+
+      setComposerDropActive(false);
+      const paths = event.paths.filter((path) => path.trim());
+      if (paths.length === 0) {
+        setStatus('拖拽内容中没有文件');
+        return;
+      }
+
+      setStatus(`正在导入附件 (${paths.length} 个)...`);
+      setAttachmentProgress?.(0);
+      try {
+        const result = await importNativeDroppedAttachmentPaths(paths, reportAttachmentProgress);
+        if (!active) return;
+        if (result.attachments.length > 0) {
+          onAttachmentsReady(result.attachments, '已拖入附件');
+        }
+        if (result.failed > 0) {
+          const prefix = result.attachments.length > 0
+            ? `已添加 ${result.attachments.length} 个附件，${result.failed} 个失败`
+            : '添加拖入附件失败';
+          setStatus(result.firstError ? `${prefix}：${result.firstError}` : prefix);
+        }
+      } catch (error) {
+        if (active) setStatus(`添加拖入附件失败：${String(error)}`);
+      } finally {
+        clearAttachmentProgress();
+      }
+    })
+      .then((nextUnlisten) => {
+        unlisten = nextUnlisten;
+      })
+      .catch((error) => {
+        setStatus(`附件拖拽不可用：${String(error)}`);
+      });
+
+    return () => {
+      active = false;
+      setComposerDropActive(false);
+      unlisten?.();
+    };
+  }, [isComposerOpen, onAttachmentsReady, setAttachmentProgress, setStatus]);
 
   async function pickDraftAttachments() {
     const newAttachments = await invoke<OutboundAttachmentInput[]>(IPC.PickOutboundAttachments);
@@ -148,7 +162,7 @@ export default function useComposerAttachments({
     if (validFiles.length === 0) return;
 
     const totalFiles = validFiles.length;
-    setStatus(`正在导入附件...`);
+    setStatus('正在导入附件...');
     reportAttachmentProgress(0, totalFiles);
     try {
       const savedAttachments: OutboundAttachmentInput[] = [];


### PR DESCRIPTION
## What changed
- Composer native file drops now attach immediately instead of reopening the file picker.
- Dropping files on the main mailbox window creates and opens a new compose draft with those files attached.
- Native dropped paths are read only through Tauri's drag-granted asset scope, then copied through the existing `save_temp_attachment` flow; no arbitrary path IPC is reintroduced.
- Multiple files and partial failures are handled without discarding successful attachments.

## Validation target
- TypeScript build/lint
- Existing composer-window race validation
- macOS/Windows real native drag/drop smoke test