### PR TITLE
feat: pin composer attachments above toolbar

### DIFF
--- a/src/components/composer/composer-polish.css
+++ b/src/components/composer/composer-polish.css
@@ -141,3 +141,83 @@
   white-space: pre-wrap;
   tab-size: 4;
 }
+
+/* Attachments live in a dedicated, always-visible strip immediately above
+   the footer tools instead of disappearing into the editor's scroll flow. */
+.composer .composer-body-attachments {
+  position: sticky;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  z-index: 5;
+  flex-wrap: nowrap;
+  gap: 8px;
+  padding: 10px 14px 11px;
+  overflow-x: auto;
+  overflow-y: hidden;
+  border-top: 1px solid var(--ui-border);
+  background: var(--ui-surface);
+  overscroll-behavior-x: contain;
+  scrollbar-width: thin;
+}
+
+.composer .composer-attachment-tile {
+  width: auto;
+  min-width: 0;
+  min-height: 62px;
+  flex: 0 0 190px;
+  grid-template-columns: 42px minmax(0, 1fr);
+  gap: 10px;
+  padding: 8px 28px 8px 9px;
+  border-radius: var(--ui-radius-control);
+}
+
+.composer .composer-attachment-filemark {
+  width: 38px;
+  height: 42px;
+}
+
+.composer .composer-attachment-filemark-icon svg {
+  width: 20px;
+  height: 20px;
+}
+
+.composer .composer-attachment-tile-copy {
+  align-content: center;
+}
+
+.composer .composer-attachment-tile-copy strong {
+  font-size: 12.5px;
+  font-weight: 600;
+}
+
+.composer .composer-attachment-tile-copy small {
+  font-size: 11px;
+}
+
+.composer .composer-attachment-tile > button {
+  position: absolute;
+  top: 5px;
+  right: 5px;
+  width: 22px;
+  min-height: 22px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  opacity: 0.72;
+}
+
+.composer .composer-attachment-tile > button:hover,
+.composer .composer-attachment-tile > button:focus-visible {
+  opacity: 1;
+}
+
+@media (max-width: 720px) {
+  .composer .composer-body-attachments {
+    padding-inline: 10px;
+  }
+
+  .composer .composer-attachment-tile {
+    flex-basis: 168px;
+  }
+}

--- a/src/components/composer/composerAttachmentStrip.test.mjs
+++ b/src/components/composer/composerAttachmentStrip.test.mjs
@@ -1,0 +1,35 @@
+import { readFileSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '..', '..', '..');
+const fieldsSource = readFileSync(
+  join(repoRoot, 'src/components/composer/ComposerPrimaryFields.tsx'),
+  'utf8',
+);
+const polishCss = readFileSync(
+  join(repoRoot, 'src/components/composer/composer-polish.css'),
+  'utf8',
+);
+
+describe('composer attachment strip', () => {
+  it('keeps regular attachments visible and removable', () => {
+    expect(fieldsSource).toContain('composer-body-attachments composer-attachment-list');
+    expect(fieldsSource).toContain('aria-label={`移除 ${attachment.filename}`}');
+    expect(fieldsSource).toContain('onClick={() => onRemoveAttachment(attachmentIndex)}');
+  });
+
+  it('pins attachments above the footer as a horizontal strip', () => {
+    expect(polishCss).toMatch(/\.composer \.composer-body-attachments\s*\{[\s\S]*?position:\s*sticky;/);
+    expect(polishCss).toMatch(/\.composer \.composer-body-attachments\s*\{[\s\S]*?bottom:\s*0;/);
+    expect(polishCss).toMatch(/\.composer \.composer-body-attachments\s*\{[\s\S]*?flex-wrap:\s*nowrap;/);
+    expect(polishCss).toMatch(/\.composer \.composer-body-attachments\s*\{[\s\S]*?overflow-x:\s*auto;/);
+  });
+
+  it('places the remove action in the attachment card top-right corner', () => {
+    expect(polishCss).toMatch(/\.composer \.composer-attachment-tile > button\s*\{[\s\S]*?position:\s*absolute;/);
+    expect(polishCss).toMatch(/\.composer \.composer-attachment-tile > button\s*\{[\s\S]*?top:\s*5px;/);
+    expect(polishCss).toMatch(/\.composer \.composer-attachment-tile > button\s*\{[\s\S]*?right:\s*5px;/);
+  });
+});


### PR DESCRIPTION
## What changed
- 附件固定显示在写信正文底部、底部工具栏正上方，不再随正文滚动消失。
- 附件改为紧凑横向单行卡片，显示文件类型、文件名和大小。
- 删除按钮固定在每个附件卡片右上角，继续复用现有 `onRemoveAttachment` 逻辑。
- 多附件横向滚动，避免挤压正文；移动端使用更紧凑宽度。
- 不改附件数据流和发送逻辑，降低回归风险。

## Validation
- 新增 attachment strip contract test，覆盖固定位置、横向布局和右上角删除按钮。
- 等待 GitHub Actions 完整 PR gate 验证。