### PR TITLE
refactor: premium compact settings popup

### DIFF
--- a/scripts/ui-smoke.mjs
+++ b/scripts/ui-smoke.mjs
@@ -553,12 +553,18 @@ async function openSettingsSection(cdp, label, section, expectedSelector) {
     await clickButton(cdp, label, "document.querySelector('.settings-nav')");
     await waitForExpression(
       cdp,
-      `document.querySelector('.settings-page-header h2')?.textContent.trim() === ${JSON.stringify(label)}
+      `((document.querySelector('.settings-page-header h2')?.textContent.trim() === ${JSON.stringify(label)})
+        || (document.querySelector('.settings-page')?.getAttribute('aria-label') === ${JSON.stringify(label)}))
         && document.querySelector('.settings-nav button[aria-current="page"]')?.textContent.includes(${JSON.stringify(label)})
-        && document.querySelector(${JSON.stringify(expectedSelector)})
-        && [...document.querySelectorAll('[data-settings-section]')]
-          .every((item) => item.dataset.settingsSection === ${JSON.stringify(section)}
-            || item.dataset.settingsSection.startsWith(${JSON.stringify(section)} + '-'))`,
+        && (() => {
+          const page = document.querySelector(${JSON.stringify(expectedSelector)});
+          return Boolean(page)
+            && [...page.querySelectorAll('[data-settings-section]')]
+              .every((item) => item.dataset.settingsSection === ${JSON.stringify(section)}
+                || item.dataset.settingsSection.startsWith(${JSON.stringify(section)} + '-')
+                || (${JSON.stringify(section)} === 'accounts' && item.dataset.settingsSection === 'account-overview')
+                || (${JSON.stringify(section)} === 'notifications' && item.dataset.settingsSection.startsWith('notification-')));
+        })()`,
     );
   });
 }
@@ -854,7 +860,7 @@ async function assertSettingsV2LayoutContract(cdp, label, viewport) {
   if (viewport === 'desktop') {
     if (data.nav && style('nav', 'display') !== 'flex') failures.push(`nav display=${style('nav', 'display')}`);
     if (data.mobileToolbar && style('mobileToolbar', 'display') !== 'none') failures.push(`mobileToolbar display=${style('mobileToolbar', 'display')}`);
-    if (data.mainHeader && style('mainHeader', 'minHeight') !== '52px') failures.push(`mainHeader minHeight=${style('mainHeader', 'minHeight')}`);
+    if (data.mainHeader && style('mainHeader', 'minHeight') !== '48px') failures.push(`mainHeader minHeight=${style('mainHeader', 'minHeight')}`);
     if (data.mainHeader && style('mainHeader', 'position') !== 'sticky') failures.push(`mainHeader position=${style('mainHeader', 'position')}`);
     if (data.pageHeader && style('pageHeader', 'minHeight') !== '78px') failures.push(`pageHeader minHeight=${style('pageHeader', 'minHeight')}`);
     if (data.content && style('content', 'paddingTop') !== '0px') failures.push(`content paddingTop=${style('content', 'paddingTop')}`);
@@ -885,11 +891,11 @@ async function assertSettingsPagesEnterable(cdp, label, pages) {
         const label = ${JSON.stringify(page.label)};
         let button = null;
         if (${JSON.stringify(page.tab === true)}) {
-          button = [...document.querySelectorAll('.settings-connection-tabs button')]
+          button = [...document.querySelectorAll('.settings-context-tabs button')]
             .find((item) => item.textContent.trim() === label);
         }
         if (!button) {
-          button = [...document.querySelectorAll('.settings-nav-section > button')]
+          button = [...document.querySelectorAll('.settings-nav-list > button')]
             .find((item) => item.textContent.trim() === label);
         }
         if (!button) return { entered: false, reason: 'nav button missing' };
@@ -902,7 +908,8 @@ async function assertSettingsPagesEnterable(cdp, label, pages) {
       await waitForExpression(
         cdp,
         `document.querySelector('.settings-page')?.dataset.settingsPage === ${JSON.stringify(page.id)}
-          && document.querySelector('.settings-page-header h2')?.textContent.trim() === ${JSON.stringify(page.headerLabel ?? page.label)}`,
+          && ((document.querySelector('.settings-page-header h2')?.textContent.trim() === ${JSON.stringify(page.headerLabel ?? page.label)})
+            || (document.querySelector('.settings-page')?.getAttribute('aria-label') === ${JSON.stringify(page.headerLabel ?? page.label)}))`,
       );
     } catch (error) {
       const probe = await evalInPage(
@@ -910,9 +917,9 @@ async function assertSettingsPagesEnterable(cdp, label, pages) {
         `(() => ({
           modalOpen: !!document.querySelector('.settings-modal'),
           page: document.querySelector('.settings-page')?.dataset.settingsPage ?? null,
-          header: document.querySelector('.settings-page-header h2')?.textContent.trim() ?? null,
-          navButtons: [...document.querySelectorAll('.settings-nav-section > button')].map((b) => b.textContent.trim()),
-          tabs: [...document.querySelectorAll('.settings-connection-tabs button')].map((b) => b.textContent.trim()),
+          header: document.querySelector('.settings-page-header h2')?.textContent.trim() ?? document.querySelector('.settings-page')?.getAttribute('aria-label') ?? null,
+          navButtons: [...document.querySelectorAll('.settings-nav-list > button')].map((b) => b.textContent.trim()),
+          tabs: [...document.querySelectorAll('.settings-context-tabs button')].map((b) => b.textContent.trim()),
         }))()`,
       );
       throw new Error(`${label}: ${page.id} navigation timed out; state=${JSON.stringify(probe)}; original=${error.message}`);
@@ -926,7 +933,7 @@ async function assertSettingsPagesEnterable(cdp, label, pages) {
         const style = page ? getComputedStyle(page) : null;
         return {
           id: page?.dataset.settingsPage ?? null,
-          title: document.querySelector('.settings-page-header h2')?.textContent.trim() ?? null,
+          title: document.querySelector('.settings-page-header h2')?.textContent.trim() ?? document.querySelector('.settings-page')?.getAttribute('aria-label') ?? null,
           rect: rect ? { left: rect.left, right: rect.right, top: rect.top, bottom: rect.bottom, width: rect.width, height: rect.height } : null,
           overflowY: style?.overflowY ?? null,
           scrollWidth: page?.scrollWidth ?? null,
@@ -1186,7 +1193,7 @@ async function seedComposeReferenceContacts(cdp) {
   return withStep('seedComposeReferenceContacts', async () => {
     await clickButton(cdp, '设置', "document.querySelector('.sidebar-footer')");
     await waitForExpression(cdp, "document.querySelector('.settings-modal')");
-    await openSettingsSection(cdp, '联系人', 'contacts', '.settings-page[data-settings-page="contacts"]');
+    await openSettingsSection(cdp, '通讯录', 'contacts', '.settings-page[data-settings-page="contacts"]');
     await waitForExpression(cdp, "document.querySelectorAll('.settings-page[data-settings-page=\"contacts\"] .contact-tool-row').length === 0");
 
     for (const contact of composeReferenceContacts) {
@@ -1453,7 +1460,7 @@ async function main() {
     await waitForExpression(cdp, "document.querySelector('.mobile-settings-root') && window.history.state?.betterEmailScreen === 'settings' && !document.querySelector('.settings-modal')");
     await waitForExpression(cdp, "(() => { const scroll = document.querySelector('.mobile-settings-scroll'); return scroll && getComputedStyle(scroll).overflowY === 'auto'; })()");
     await evalInPage(cdp, "[...document.querySelectorAll('.mobile-settings-row')].find((item) => item.textContent.includes('联系人'))?.click()");
-    await waitForExpression(cdp, "document.querySelector('.settings-modal[data-ui=\"settings-v2\"]') && document.querySelector('.settings-page[data-settings-page=\"contacts\"]') && window.history.state?.betterEmailSettingsSection === 'contacts'");
+    await waitForExpression(cdp, "document.querySelector('.settings-modal[data-ui=\"settings-v3\"]') && document.querySelector('.settings-page[data-settings-page=\"contacts\"]') && window.history.state?.betterEmailSettingsSection === 'contacts'");
     await evalInPage(cdp, "document.querySelector('.settings-close-button[aria-label=\"关闭设置\"]')?.click()");
     await waitForExpression(cdp, "document.querySelector('.mobile-settings-root') && !document.querySelector('.settings-modal') && window.history.state?.betterEmailScreen === 'settings' && !window.history.state?.betterEmailSettingsSection");
     await evalInPage(cdp, "document.querySelector('.mobile-settings-header .mobile-header-icon[aria-label=\"返回邮箱\"]')?.click()");
@@ -1668,7 +1675,7 @@ async function main() {
     await waitForExpression(cdp, "!document.querySelector('.contact-center') && !document.body.innerText.includes('搜索联系人')");
     await clickButton(cdp, '设置', "document.querySelector('.sidebar-footer')");
     await waitForExpression(cdp, "document.querySelector('.settings-modal') && document.querySelector('.settings-nav')");
-    await openSettingsSection(cdp, '联系人', 'contacts', '.settings-page[data-settings-page="contacts"]');
+    await openSettingsSection(cdp, '通讯录', 'contacts', '.settings-page[data-settings-page="contacts"]');
     await waitForExpression(cdp, "document.querySelector('.settings-page[data-settings-page=\"contacts\"]')?.innerText.includes('还没有联系人')");
     await openContactCreateDialog(cdp);
     await fillInput(cdp, '.contact-create-form input[placeholder="联系人名称"]', 'Ada');
@@ -1762,7 +1769,7 @@ async function main() {
     await waitForExpression(cdp, "document.querySelectorAll('.message-card').length >= 2");
     await clickButton(cdp, '设置', "document.querySelector('.sidebar-footer')");
     await waitForExpression(cdp, "document.querySelector('.settings-modal')");
-    await openSettingsSection(cdp, '联系人', 'contacts', '.settings-page[data-settings-page=\"contacts\"]');
+    await openSettingsSection(cdp, '通讯录', 'contacts', '.settings-page[data-settings-page=\"contacts\"]');
     const contactsNeedComposeSeed = await evalInPage(cdp, "![...document.querySelectorAll('.contact-tool-row')].some((row) => row.innerText.includes('ada@example.com'))");
     if (contactsNeedComposeSeed) {
       await openContactCreateDialog(cdp);
@@ -2196,8 +2203,8 @@ async function main() {
     await evalInPage(cdp, "document.querySelector('[data-context-item=\"account-scope-3\"]').click()");
     await waitForExpression(cdp, "document.querySelector('.account-switcher[data-account-scope=\"3\"]')?.innerText.includes('archive@better-email.local')");
     await clickButton(cdp, '设置');
-    await waitForExpression(cdp, "document.querySelector('.settings-title strong')?.textContent.trim() === '设置' && document.querySelector('.settings-page-header')?.innerText.includes('账号') && !document.body.innerText.includes('OAuth2 向导')");
-    await waitForExpression(cdp, "document.querySelector('.settings-page')?.dataset.settingsPage === 'accounts' && document.querySelectorAll('.settings-page').length === 1 && document.querySelectorAll('.settings-nav-section > button').length === 14 && document.querySelector('.settings-nav-search input[aria-label^=\"搜索设置页面\"]')");
+    await waitForExpression(cdp, "document.querySelector('.settings-title strong')?.textContent.trim() === '设置' && document.querySelector('.settings-page[data-settings-page=\"accounts\"]')?.getAttribute('aria-label') === '账号' && !document.body.innerText.includes('OAuth2 向导')");
+    await waitForExpression(cdp, "document.querySelector('.settings-page')?.dataset.settingsPage === 'accounts' && document.querySelectorAll('.settings-page').length === 1 && document.querySelectorAll('.settings-nav-list > button').length === 11 && document.querySelector('.settings-nav-search input[aria-label=\"搜索设置\"]')");
     await evalInPage(
       cdp,
       `(() => {
@@ -2209,9 +2216,9 @@ async function main() {
         element.dispatchEvent(new InputEvent('input', { bubbles: true, inputType: 'insertText', data: '隐私' }));
       })()`,
     );
-    await waitForExpression(cdp, "document.querySelectorAll('.settings-nav-section > button').length === 1 && document.querySelector('.settings-nav-section > button')?.innerText.includes('隐私')");
+    await waitForExpression(cdp, "document.querySelectorAll('.settings-search-results > button').length === 1 && document.querySelector('.settings-search-results > button')?.innerText.includes('隐私')");
     await evalInPage(cdp, "document.querySelector('.settings-nav-search button[aria-label=\"清空设置搜索\"]').click()");
-    await waitForExpression(cdp, "document.querySelectorAll('.settings-nav-section > button').length === 14");
+    await waitForExpression(cdp, "document.querySelectorAll('.settings-nav-list > button').length === 11");
     await evalInPage(cdp, "document.querySelector('.settings-page-picker').click()");
     await waitForExpression(cdp, "document.querySelector('.settings-mobile-menu') && [...document.querySelectorAll('.settings-mobile-menu [role=\"menuitem\"]')].some((item) => item.innerText.includes('发送'))");
     await evalInPage(cdp, "[...document.querySelectorAll('.settings-mobile-menu [role=\"menuitem\"]')].find((item) => item.innerText.includes('发送')).click()");
@@ -2219,12 +2226,12 @@ async function main() {
     await evalInPage(cdp, "document.querySelector('.settings-page-picker').click()");
     await waitForExpression(cdp, "document.querySelector('.settings-mobile-menu') && [...document.querySelectorAll('.settings-mobile-menu [role=\"menuitem\"]')].some((item) => item.innerText.includes('账号'))");
     await evalInPage(cdp, "[...document.querySelectorAll('.settings-mobile-menu [role=\"menuitem\"]')].find((item) => item.innerText.includes('账号')).click()");
-    await waitForExpression(cdp, "!document.querySelector('.settings-mobile-menu') && document.querySelector('.settings-page')?.dataset.settingsPage === 'accounts' && document.querySelector('.settings-page-header h2')?.textContent.trim() === '账号'");
+    await waitForExpression(cdp, "!document.querySelector('.settings-mobile-menu') && document.querySelector('.settings-page[data-settings-page=\"accounts\"]')?.getAttribute('aria-label') === '账号'");
     await clickButton(cdp, '发送', "document.querySelector('.settings-nav')");
     await waitForExpression(cdp, "document.querySelector('.settings-page')?.dataset.settingsPage === 'sending' && document.querySelector('.settings-page-header h2')?.textContent.trim() === '发送'");
     await clickButton(cdp, '账号', "document.querySelector('.settings-nav')");
-    await waitForExpression(cdp, "document.querySelector('.settings-page')?.dataset.settingsPage === 'accounts' && document.querySelector('.settings-page-header h2')?.textContent.trim() === '账号'");
-    await clickButton(cdp, '认证', "document.querySelector('.settings-connection-tabs')");
+    await waitForExpression(cdp, "document.querySelector('.settings-page[data-settings-page=\"accounts\"]')?.getAttribute('aria-label') === '账号'");
+    await clickButton(cdp, '登录与安全', "document.querySelector('.settings-context-tabs')");
     await waitForExpression(cdp, "document.querySelector('.settings-page')?.dataset.settingsPage === 'auth' && document.querySelector('.settings-oauth-primary')");
     await openDetails(cdp, '.settings-provider-advanced');
     await assertSettingsAuthOAuth2Alignment(cdp, '认证 OAuth2 模式 1440x980');
@@ -2283,7 +2290,7 @@ async function main() {
     await waitForExpression(cdp, "document.querySelector('[data-context-item=\"account-scope-2\"]')?.innerText.includes('默认发件') && document.querySelector('[data-context-item=\"set-default-account\"]').disabled");
     await evalInPage(cdp, "window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }))");
     await clickButton(cdp, '设置');
-    await waitForExpression(cdp, "document.querySelector('.settings-title strong')?.textContent.trim() === '设置' && document.querySelector('.settings-page-header h2')?.textContent.trim() === '账号' && document.querySelector('.settings-page[data-settings-page=\"accounts\"]') && [...document.querySelectorAll('[data-settings-section]')].every((item) => item.dataset.settingsSection === 'accounts')");
+    await waitForExpression(cdp, "document.querySelector('.settings-title strong')?.textContent.trim() === '设置' && document.querySelector('.settings-page[data-settings-page=\"accounts\"]')?.getAttribute('aria-label') === '账号' && document.querySelector('.settings-page[data-settings-page=\"accounts\"] [data-settings-section=\"account-overview\"]')");
     // 账号页头部为干净的 v2 头：只保留关闭按钮，不再有旧版保存动作栏。
     await waitForExpression(cdp, "document.querySelector('.settings-header-actions button[aria-label=\"关闭设置\"]') && !document.querySelector('.settings-action-bar')");
     await waitForExpression(cdp, "!document.querySelector('.add-account-disclosure')?.open");
@@ -2291,7 +2298,7 @@ async function main() {
     await captureScreenshot(cdp, 'settings-account-desktop');
     // 账号列表呈现 3 个种子账号（保存与验证动作在账号配置/认证页内）。
     await waitForExpression(cdp, "[...document.querySelectorAll('.settings-account-row')].filter((row) => row.innerText.includes('@better-email.local')).length === 3");
-    await openSettingsSection(cdp, '备份', 'backup', '.settings-page[data-settings-page="backup"]');
+    await openSettingsSection(cdp, '数据与存储', 'backup', '.settings-page[data-settings-page="backup"]');
     // 备份页核心内容：本地存储统计（连接端点/凭据验证在认证页单独断言）。
     await waitForExpression(cdp, "document.querySelector('.settings-page[data-settings-page=\"backup\"]') && document.querySelector('[data-storage-total]')");
     await openSettingsSection(cdp, '发送', 'sending', '.settings-page[data-settings-page="sending"]');
@@ -2304,7 +2311,7 @@ async function main() {
     await waitForExpression(cdp, "window.innerWidth === 430 && getComputedStyle(document.querySelector('.settings-nav')).display === 'none' && getComputedStyle(document.querySelector('.settings-mobile-toolbar')).display === 'block' && document.querySelector('.settings-page-picker[aria-label=\"切换设置页面\"]')?.getAttribute('aria-expanded') === 'false' && document.querySelector('.settings-page-picker')?.innerText.includes('发送') && document.querySelector('.settings-content').scrollWidth === document.querySelector('.settings-content').clientWidth");
     await waitForExpression(cdp, "(() => { const content = document.querySelector('.settings-content'); const toolbar = document.querySelector('.settings-mobile-toolbar'); const page = document.querySelector('.settings-page'); return content && toolbar && page && getComputedStyle(page).overflowY === 'auto' && page.clientHeight >= 200 && page.clientHeight <= content.clientHeight - toolbar.offsetHeight + 40; })()");
     await evalInPage(cdp, "document.querySelector('.settings-page-picker').click()");
-    await waitForExpression(cdp, "document.querySelector('.settings-mobile-menu') && document.querySelectorAll('.settings-mobile-menu [role=\"menuitem\"]').length === 14 && document.querySelector('.settings-page-picker')?.getAttribute('aria-expanded') === 'true'");
+    await waitForExpression(cdp, "document.querySelector('.settings-mobile-menu') && document.querySelectorAll('.settings-mobile-menu [role=\"menuitem\"]').length === 11 && document.querySelector('.settings-page-picker')?.getAttribute('aria-expanded') === 'true'");
     await captureScreenshot(cdp, 'settings-page-picker-narrow');
     await evalInPage(cdp, "[...document.querySelectorAll('.settings-mobile-menu [role=\"menuitem\"]')].find((item) => item.innerText.includes('发送')).click()");
     await waitForExpression(cdp, "!document.querySelector('.settings-mobile-menu') && document.querySelector('.settings-page')?.dataset.settingsPage === 'sending'");
@@ -2321,15 +2328,15 @@ async function main() {
     await pickCustomSelect(cdp, '.settings-page[data-settings-page="sending"] .custom-select-summary', '5 秒');
     await waitForExpression(cdp, "localStorage.getItem('better-email.sendUndoDelaySeconds') === '5' && document.querySelector('.settings-page[data-settings-page=\"sending\"]').innerText.includes('5 秒')");
     await clickButton(cdp, '账号', "document.querySelector('.settings-nav')");
-    await waitForExpression(cdp, "document.querySelector('.settings-page')?.dataset.settingsPage === 'accounts' && document.querySelector('.settings-page-header h2')?.textContent.trim() === '账号'");
-    await clickButton(cdp, '服务器', "document.querySelector('.settings-connection-tabs')");
+    await waitForExpression(cdp, "document.querySelector('.settings-page[data-settings-page=\"accounts\"]')?.getAttribute('aria-label') === '账号'");
+    await clickButton(cdp, '服务器', "document.querySelector('.settings-context-tabs')");
     await waitForExpression(cdp, "document.querySelector('.settings-page')?.dataset.settingsPage === 'providers' && document.querySelector('.settings-provider-advanced')");
     await waitForExpression(cdp, "!document.querySelector('details[data-settings-section=\"providers\"]')?.open && [...document.querySelectorAll('.settings-nav button')].some((item) => item.textContent.trim() === '发送')");
     await waitForSettingsPageStable(cdp);
     await captureScreenshot(cdp, 'settings-providers-closed-desktop');
     await openDetails(cdp, 'details[data-settings-section=\"providers\"]');
     await waitForExpression(cdp, "document.querySelector('details[data-settings-section=\"providers\"]')?.open && document.querySelector('details[data-settings-section=\"providers\"]')?.textContent.includes('真实账号已验证') && document.body.innerText.includes('兼容性矩阵')");
-    await waitForExpression(cdp, "(() => { const header = document.querySelector('.settings-page-header')?.getBoundingClientRect(); const content = document.querySelector('.settings-page-content')?.getBoundingClientRect(); return header && content && header.bottom <= content.top + 1; })()");
+    await waitForExpression(cdp, "(() => { const workspace = document.querySelector('.settings-account-workspace')?.getBoundingClientRect(); const content = document.querySelector('.settings-page-content')?.getBoundingClientRect(); return workspace && content && workspace.bottom <= content.top + 1; })()");
     await waitForSettingsPageStable(cdp);
     await captureScreenshot(cdp, 'settings-providers-desktop');
     await assertSettingsProvidersGeometry(cdp, '服务器页 1440x980');
@@ -2359,7 +2366,7 @@ async function main() {
     });
     await waitForExpression(cdp, 'window.innerWidth === 1440');
     await waitForSettingsPageStable(cdp);
-    await clickButton(cdp, '认证', "document.querySelector('.settings-connection-tabs')");
+    await clickButton(cdp, '登录与安全', "document.querySelector('.settings-context-tabs')");
     await waitForExpression(cdp, "document.querySelector('.settings-credential-panel')?.innerText.includes('本地凭据存储') && document.querySelector('.credential-safety-points')?.innerText.includes('保存后立即清空输入框') && document.querySelector('.settings-credential-panel')?.innerText.includes('验证登录')");
     await waitForExpression(cdp, "document.querySelector('.settings-credential-panel .credential-guide-card') && document.querySelector('.credential-provider-tag')");
     await waitForSettingsPageStable(cdp);
@@ -2379,7 +2386,10 @@ async function main() {
     await waitForExpression(cdp, "document.querySelector('[data-provider-validation-status=\"success\"]') && [...document.querySelectorAll('[data-provider-validation-stage]')].length === 4 && [...document.querySelectorAll('[data-provider-validation-stage]')].every((stage) => stage.classList.contains('success')) && document.querySelector('[data-provider-validation]')?.innerText.includes('未发送邮件或修改远端邮件状态')");
     await evalInPage(cdp, "document.querySelector('.connection-technical-details > summary').click()");
     await waitForExpression(cdp, "document.querySelector('.connection-technical-details')?.open && document.querySelector('.connection-technical-details')?.textContent.includes('未发送任何邮件') && document.querySelector('.connection-technical-details')?.textContent.includes('不显示或导出授权码与 Token')");
-    await openSettingsSection(cdp, '同步', 'sync', '.settings-page[data-settings-page="sync"]');
+    await clickButton(cdp, '账号', "document.querySelector('.settings-nav')");
+    await waitForExpression(cdp, "document.querySelector('.settings-page[data-settings-page=\"accounts\"]')?.getAttribute('aria-label') === '账号'");
+    await clickButton(cdp, '同步', "document.querySelector('.settings-context-tabs')");
+    await waitForExpression(cdp, "document.querySelector('.settings-page[data-settings-page=\"sync\"]')");
     await waitForExpression(cdp, "document.body.innerText.includes('同步调度与限流') && document.body.innerText.includes('每轮最多 2 个账号') && document.body.innerText.includes('Smoke Outbox Flow') && document.body.innerText.includes('排队中')");
     await waitForSettingsPageStable(cdp);
     await captureScreenshot(cdp, 'settings-sync-desktop');
@@ -2392,17 +2402,20 @@ async function main() {
     await waitForExpression(cdp, "document.querySelector('[data-imap-mailbox=\"Projects/Alpha\"]')?.innerText.includes('5750')");
     await clickButton(cdp, '演练', "document.querySelector('.settings-page[data-settings-page=\"sync\"]')");
     await waitForExpression(cdp, "document.querySelector('.settings-page[data-settings-page=\"sync\"]')?.innerText.includes('design@better-email.local')");
-    await clickButton(cdp, '同步邮件头', "document.querySelector('.settings-page[data-settings-page=\"sync\"]')");
+    await clickButton(cdp, '同步邮件', "document.querySelector('.settings-page[data-settings-page=\"sync\"]')");
     await waitForExpression(cdp, "document.body.innerText.includes('4 个已映射文件夹')");
     await openSettingsSection(cdp, '通知', 'notifications', '.settings-page[data-settings-page="notifications"]');
-    await waitForExpression(cdp, "document.body.innerText.includes('账号通知优先级') && document.body.innerText.includes('正常通知') && document.body.innerText.includes('优先提醒') && document.body.innerText.includes('不通知') && document.querySelector('.notification-account-grid')");
-    await evalInPage(cdp, "(() => { const row = document.querySelector('[data-notification-account=\"design@better-email.local\"]'); const button = [...row.querySelectorAll('button')].find((item) => item.textContent.trim() === '优先提醒'); if (!button) throw new Error('Priority notification button not found'); button.click(); })()");
-    await waitForExpression(cdp, "(() => { const policy = JSON.parse(localStorage.getItem('better-email.notificationPolicy')); const row = document.querySelector('[data-notification-account=\"design@better-email.local\"]'); return policy.priorityAccounts.includes('design@better-email.local') && !policy.mutedAccounts.includes('design@better-email.local') && row.querySelector('button[aria-pressed=\"true\"]')?.textContent.trim() === '优先提醒'; })()");
-    await evalInPage(cdp, "(() => { const row = document.querySelector('[data-notification-account=\"design@better-email.local\"]'); const button = [...row.querySelectorAll('button')].find((item) => item.textContent.trim() === '不通知'); if (!button) throw new Error('Muted notification button not found'); button.click(); })()");
-    await waitForExpression(cdp, "(() => { const policy = JSON.parse(localStorage.getItem('better-email.notificationPolicy')); const row = document.querySelector('[data-notification-account=\"design@better-email.local\"]'); return policy.mutedAccounts.includes('design@better-email.local') && !policy.priorityAccounts.includes('design@better-email.local') && row.querySelector('button[aria-pressed=\"true\"]')?.textContent.trim() === '不通知'; })()");
-    await openSettingsSection(cdp, '隐私', 'privacy', '.settings-page[data-settings-page="privacy"]');
-    await waitForExpression(cdp, "document.querySelector('.settings-page[data-settings-page=\"privacy\"] .custom-select-summary[aria-label=\"配置账号\"]') && document.querySelector('.settings-page[data-settings-page=\"privacy\"]')?.innerText.includes('允许此账号加载远程图片')");
-    await openSettingsSection(cdp, '备份', 'backup', '.settings-page[data-settings-page="backup"]');
+    await waitForExpression(cdp, "document.body.innerText.includes('账号通知优先级') && document.body.innerText.includes('正常') && document.body.innerText.includes('优先') && document.body.innerText.includes('静音') && document.querySelector('.notification-account-grid')");
+    await evalInPage(cdp, "(() => { const row = document.querySelector('[data-notification-account=\"design@better-email.local\"]'); const button = row && [...row.querySelectorAll('button')].find((item) => item.textContent.trim() === '优先'); if (!button) throw new Error('Priority notification button not found'); button.click(); })()");
+    await waitForExpression(cdp, "(() => { const policy = JSON.parse(localStorage.getItem('better-email.notificationPolicy')); const row = document.querySelector('[data-notification-account=\"design@better-email.local\"]'); return policy.priorityAccounts.includes('design@better-email.local') && !policy.mutedAccounts.includes('design@better-email.local') && row.querySelector('button[aria-pressed=\"true\"]')?.textContent.trim() === '优先'; })()");
+    await evalInPage(cdp, "(() => { const row = document.querySelector('[data-notification-account=\"design@better-email.local\"]'); const button = row && [...row.querySelectorAll('button')].find((item) => item.textContent.trim() === '静音'); if (!button) throw new Error('Muted notification button not found'); button.click(); })()");
+    await waitForExpression(cdp, "(() => { const policy = JSON.parse(localStorage.getItem('better-email.notificationPolicy')); const row = document.querySelector('[data-notification-account=\"design@better-email.local\"]'); return policy.mutedAccounts.includes('design@better-email.local') && !policy.priorityAccounts.includes('design@better-email.local') && row.querySelector('button[aria-pressed=\"true\"]')?.textContent.trim() === '静音'; })()");
+    await clickButton(cdp, '账号', "document.querySelector('.settings-nav')");
+    await waitForExpression(cdp, "document.querySelector('.settings-page[data-settings-page=\"accounts\"]')?.getAttribute('aria-label') === '账号'");
+    await clickButton(cdp, '隐私', "document.querySelector('.settings-context-tabs')");
+    await waitForExpression(cdp, "document.querySelector('.settings-page[data-settings-page=\"privacy\"]')");
+    await waitForExpression(cdp, "document.querySelector('.settings-page[data-settings-page=\"privacy\"]')?.innerText.includes('允许加载远程图片') && document.querySelector('.settings-page[data-settings-page=\"privacy\"]')?.innerText.includes('提示外部发件人') && !document.querySelector('.settings-page[data-settings-page=\"privacy\"] .custom-select-summary[aria-label=\"配置账号\"]')");
+    await openSettingsSection(cdp, '数据与存储', 'backup', '.settings-page[data-settings-page="backup"]');
     await waitForExpression(cdp, "document.querySelector('[data-storage-total]')?.textContent !== '—' && document.querySelector('[data-storage-reclaimable]')?.textContent.includes('MB') && ![...document.querySelectorAll('.settings-storage-actions button')].find((item) => item.textContent.includes('清理缓存'))?.disabled");
     await waitForSettingsPageStable(cdp);
     await captureScreenshot(cdp, 'settings-storage-desktop');
@@ -2419,7 +2432,7 @@ async function main() {
     await clickButton(cdp, '导出本地备份');
     await waitForExpression(cdp, "document.body.innerText.includes('/tmp/better-email-backup.json') && document.body.innerText.includes('凭据未包含')");
 
-    await openSettingsSection(cdp, '联系人', 'contacts', '.settings-page[data-settings-page="contacts"]');
+    await openSettingsSection(cdp, '通讯录', 'contacts', '.settings-page[data-settings-page="contacts"]');
     await waitForExpression(cdp, "document.querySelector('.settings-page[data-settings-page=\"contacts\"] .contact-transfer-actions') && (document.querySelectorAll('.contact-tool-row').length > 0 || document.querySelector('.settings-page[data-settings-page=\"contacts\"]')?.innerText.includes('还没有联系人'))");
     const contactsNeedSeed = await evalInPage(cdp, "![...document.querySelectorAll('.contact-tool-row')].some((row) => row.innerText.includes('ada@example.com'))");
     if (contactsNeedSeed) {
@@ -2472,7 +2485,7 @@ async function main() {
     await clickButton(cdp, '导出 vCard', "document.querySelector('.contact-transfer-actions')");
     await waitForExpression(cdp, "document.querySelector('.status-line')?.textContent.includes('已导出') && document.querySelector('.status-line')?.textContent.includes('/tmp/better-email-contacts.vcf')");
 
-    await openSettingsSection(cdp, '规则', 'rules', '.settings-page[data-settings-page="rules"]');
+    await openSettingsSection(cdp, '自动化', 'rules', '.settings-page[data-settings-page="rules"]');
     await waitForExpression(cdp, "document.querySelector('.settings-rule-editor') && document.querySelector('.settings-rule-builder') && document.querySelector('.settings-rule-action-chips') && document.querySelector('.settings-rule-advanced') && document.querySelector('.settings-rule-item') && document.querySelector('.settings-page[data-settings-page=\"rules\"] .settings-rule-editor input[placeholder=\"规则名称\"]')");
     const ruleOverflow1440 = await evalInPage(
       cdp,
@@ -2648,7 +2661,10 @@ async function main() {
     await waitForExpression(cdp, 'window.innerWidth === 1440');
     await waitForSettingsPageStable(cdp);
 
-    await openSettingsSection(cdp, '同步', 'sync', '.settings-page[data-settings-page="sync"]');
+    await clickButton(cdp, '账号', "document.querySelector('.settings-nav')");
+    await waitForExpression(cdp, "document.querySelector('.settings-page[data-settings-page=\"accounts\"]')?.getAttribute('aria-label') === '账号'");
+    await clickButton(cdp, '同步', "document.querySelector('.settings-context-tabs')");
+    await waitForExpression(cdp, "document.querySelector('.settings-page[data-settings-page=\"sync\"]')");
     await clickButton(cdp, '撤回', "document.querySelector('.settings-page[data-settings-page=\"sync\"]')");
     await waitForExpression(cdp, "document.querySelector('.status-line')?.textContent.includes('已撤回到草稿箱') && document.querySelector('.settings-page[data-settings-page=\"sync\"]')?.innerText.includes('已撤回到草稿箱')");
 
@@ -2662,7 +2678,10 @@ async function main() {
     await closeComposer(cdp);
     await clickButton(cdp, '设置');
     await waitForExpression(cdp, "document.querySelector('.settings-modal') && document.querySelector('.settings-header-actions')");
-    await openSettingsSection(cdp, '同步', 'sync', '.settings-page[data-settings-page="sync"]');
+    await clickButton(cdp, '账号', "document.querySelector('.settings-nav')");
+    await waitForExpression(cdp, "document.querySelector('.settings-page[data-settings-page=\"accounts\"]')?.getAttribute('aria-label') === '账号'");
+    await clickButton(cdp, '同步', "document.querySelector('.settings-context-tabs')");
+    await waitForExpression(cdp, "document.querySelector('.settings-page[data-settings-page=\"sync\"]')");
     await waitForExpression(cdp, "(() => { const stored = JSON.parse(localStorage.getItem('better-email.providerWriteValidationIds.v1') || '{}'); const panel = document.querySelector('.write-validation-status'); const pageButtons = [...document.querySelectorAll('.settings-page[data-settings-page=\"sync\"] button')]; return Boolean(stored['2']) && panel?.dataset.writeValidationId === stored['2'] && panel.querySelectorAll('[data-validation-stage]').length === 5 && document.querySelector('.settings-page[data-settings-page=\"sync\"]')?.innerText.includes('核心步骤') && !pageButtons.find((button) => button.textContent.includes('刷新状态'))?.disabled && pageButtons.filter((button) => button.textContent.includes('定位')).every((button) => button.disabled); })()");
     await clickButton(cdp, '刷新状态', "document.querySelector('.settings-page[data-settings-page=\"sync\"]')");
     await waitForExpression(cdp, "document.querySelector('.status-line')?.textContent.includes('暂未找到已发送或收件副本') && document.querySelector('[data-validation-stage=\"smtp\"]')?.innerText.includes('真实发送仍需手动确认')");
@@ -2670,13 +2689,13 @@ async function main() {
 
     await assertSettingsPagesEnterable(cdp, 'settings-v2 五页可进入 1440x980', [
       { id: 'sending', label: '发送' },
-      { id: 'ai', label: 'AI 服务' },
+      { id: 'ai', label: 'AI 与集成' },
       { id: 'accounts', label: '账号' },
-      { id: 'providers', label: '服务器', tab: true, headerLabel: '账号' },
-      { id: 'auth', label: '认证', tab: true, headerLabel: '账号' },
+      { id: 'providers', label: '服务器', tab: true },
+      { id: 'auth', label: '登录与安全', tab: true },
     ]);
     await clickButton(cdp, '账号', "document.querySelector('.settings-nav')");
-    await waitForExpression(cdp, "document.querySelector('.settings-page')?.dataset.settingsPage === 'accounts' && document.querySelector('.settings-page-header h2')?.textContent.trim() === '账号'");
+    await waitForExpression(cdp, "document.querySelector('.settings-page[data-settings-page=\"accounts\"]')?.getAttribute('aria-label') === '账号'");
 
     await openSettingsSection(cdp, '账号', 'accounts', '.settings-page[data-settings-page="accounts"]');
     // 账号页头部为干净的 v2 头契约：无旧版保存动作栏，保存与验证在账号配置/认证页内。
@@ -2713,8 +2732,11 @@ async function main() {
     await waitForExpression(cdp, "!document.querySelector('.first-run-onboarding-backdrop')");
     await waitForExpression(cdp, "document.querySelector('.settings-account-list-panel')?.innerText.includes('qa-new@better-email.local')");
     await waitForExpression(cdp, "document.querySelector('.account-switcher')?.innerText.includes('qa-new@better-email.local') && document.querySelector('.folder-list')?.innerText.includes('收件箱') && document.querySelector('.folder-list')?.innerText.includes('已发送') && document.querySelector('.folder-list')?.innerText.includes('草稿箱') && document.querySelector('.folder-list')?.innerText.includes('归档')");
-    await openSettingsSection(cdp, '身份', 'identities', '.settings-page[data-settings-page="identities"]');
-    await waitForExpression(cdp, "document.querySelector('.settings-page[data-settings-page=\"identities\"]')?.innerText.includes('QA New') && document.querySelector('.settings-page[data-settings-page=\"identities\"]')?.innerText.includes('1 个身份')");
+    await clickButton(cdp, '账号', "document.querySelector('.settings-nav')");
+    await waitForExpression(cdp, "document.querySelector('.settings-page[data-settings-page=\"accounts\"]')?.getAttribute('aria-label') === '账号'");
+    await clickButton(cdp, '身份与签名', "document.querySelector('.settings-context-tabs')");
+    await waitForExpression(cdp, "document.querySelector('.settings-page[data-settings-page=\"identities\"]')");
+    await waitForExpression(cdp, "document.querySelector('.settings-page[data-settings-page=\"identities\"]')?.innerText.includes('QA New') && document.querySelector('.settings-page[data-settings-page=\"identities\"]')?.innerText.includes('1 个')");
     await openSettingsSection(cdp, '账号', 'accounts', '.settings-page[data-settings-page="accounts"]');
     await clickButton(cdp, '会话', "document.querySelector('.list-control-actions')");
     await waitForExpression(cdp, "document.querySelector('.thread-list') && document.querySelectorAll('.thread-card').length === 0");
@@ -2892,9 +2914,12 @@ async function main() {
 
     await clickButton(cdp, '设置');
     await waitForExpression(cdp, "document.querySelector('.settings-title strong')?.textContent.trim() === '设置'");
-    await clickButton(cdp, '隐私', "document.querySelector('.settings-nav')");
+    await clickButton(cdp, '账号', "document.querySelector('.settings-nav')");
+    await waitForExpression(cdp, "document.querySelector('.settings-page[data-settings-page=\"accounts\"]')?.getAttribute('aria-label') === '账号'");
+    await clickButton(cdp, 'Demo User', "document.querySelector('.settings-page[data-settings-page=\"accounts\"] .settings-account-list')");
+    await waitForExpression(cdp, "document.querySelector('.settings-account-row.active')?.innerText.includes('demo@better-email.local')");
+    await clickButton(cdp, '隐私', "document.querySelector('.settings-context-tabs')");
     await waitForExpression(cdp, "document.querySelector('.settings-page[data-settings-page=\"privacy\"]') && document.body.innerText.includes('拦截外部邮箱邮件') && document.body.innerText.includes('隐藏邮件中的链接')");
-    await pickCustomSelect(cdp, '.settings-page[data-settings-page="privacy"] .custom-select-summary[aria-label="配置账号"]', 'demo@better-email.local');
     await evalInPage(cdp, "(() => { const boxes = [...document.querySelectorAll('.settings-page[data-settings-page=\"privacy\"] input[type=\"checkbox\"]')]; const target = boxes[1]; if (!target) throw new Error('External mailbox toggle not found'); target.click(); })()");
     await waitForExpression(cdp, "[...document.querySelectorAll('.settings-page[data-settings-page=\"privacy\"] input[type=\"checkbox\"]')][1]?.checked");
     await clickButton(cdp, '账号', "document.querySelector('.settings-nav')");
@@ -2942,12 +2967,12 @@ async function main() {
 
     await clickButton(cdp, '设置');
     await waitForExpression(cdp, "document.querySelector('.settings-modal')");
-    await openSettingsSection(cdp, 'AI 服务', 'ai', '.settings-page[data-settings-page="ai"]');
+    await openSettingsSection(cdp, 'AI 与集成', 'ai', '.settings-page[data-settings-page="ai"]');
     await sleep(800);
     await evalInPage(cdp, "(() => { const checkbox = [...document.querySelectorAll('.settings-page[data-settings-page=\"ai\"] input[type=\"checkbox\"]')][0]; if (!checkbox) throw new Error('AI enable checkbox not found'); if (!checkbox.checked) checkbox.click(); })()");
     await waitForExpression(cdp, "[...document.querySelectorAll('.settings-page[data-settings-page=\"ai\"] input[type=\"checkbox\"]')][0]?.checked");
-    await pickCustomSelect(cdp, '.settings-page[data-settings-page="ai"] .custom-select-summary', '本地演示模式 (Mock)');
-    await waitForExpression(cdp, "document.querySelector('.settings-page[data-settings-page=\"ai\"] .custom-select-summary')?.innerText.includes('本地演示模式 (Mock)')");
+    await pickCustomSelect(cdp, '.settings-page[data-settings-page="ai"] .custom-select-summary', '本地演示');
+    await waitForExpression(cdp, "document.querySelector('.settings-page[data-settings-page=\"ai\"] .custom-select-summary')?.innerText.includes('本地演示')");
     await clickButton(cdp, '测试连接', "document.querySelector('.settings-page[data-settings-page=\"ai\"]')");
     await waitForExpression(cdp, "document.querySelector('.settings-ai-test-result.ok')?.innerText.includes('模拟 AI 服务连接正常')");
     await openSettingsSection(cdp, '模板', 'templates', '.settings-page[data-settings-page="templates"]');

--- a/src/components/settings/AccountConnectionSettings.tsx
+++ b/src/components/settings/AccountConnectionSettings.tsx
@@ -64,15 +64,16 @@ export type AccountConnectionSettingsProps = {
 
 const saveAndVerifyStateLabels = {
   pending: '等待',
-  running: '进行中',
-  success: '通过',
+  running: '验证中',
+  success: '连接正常',
   partial: '部分通过',
-  error: '失败',
+  error: '连接失败',
   needs_auth: '需要认证',
 } as const;
 
 export default function AccountConnectionSettings(props: AccountConnectionSettingsProps) {
-  const showSaveAndVerifyStatus = Boolean(props.accountForm)
+  const showDiagnostics = Boolean(props.accountForm)
+    && props.section !== 'accounts'
     && props.saveAndVerifyReport.overall !== 'pending';
   let page: React.ReactNode;
 
@@ -137,35 +138,34 @@ export default function AccountConnectionSettings(props: AccountConnectionSettin
 
   return (
     <div className="settings-connection-shell">
-      {showSaveAndVerifyStatus && props.section !== 'accounts' && (
-        <section
-          className={`settings-save-verify-status ${props.saveAndVerifyReport.overall}`}
-          aria-label="账号保存与验证状态"
-        >
-          <header>
+      {page}
+      {showDiagnostics && (
+        <details className="settings-disclosure settings-connection-diagnostics">
+          <summary>
             <span>
-              <strong>账号连接状态</strong>
+              <strong>连接诊断</strong>
               <small>{props.saveAndVerifyReport.summary}</small>
             </span>
             <em>{saveAndVerifyStateLabels[props.saveAndVerifyReport.overall]}</em>
-          </header>
-          <div className="settings-save-verify-stages">
-            {props.saveAndVerifyReport.stages.map((stage) => (
-              <span className={stage.state} key={stage.id}>
-                <b>{stage.label}</b>
-                <small>{stage.detail}</small>
-              </span>
-            ))}
+          </summary>
+          <div className="settings-disclosure-body">
+            <div className="settings-save-verify-stages">
+              {props.saveAndVerifyReport.stages.map((stage) => (
+                <span className={stage.state} key={stage.id}>
+                  <b>{stage.label}</b>
+                  <small>{stage.detail}</small>
+                </span>
+              ))}
+            </div>
+            {props.saveAndVerifyReport.technicalDetails.length > 0 && (
+              <details className="settings-technical-details">
+                <summary>技术详情</summary>
+                <pre>{props.saveAndVerifyReport.technicalDetails.join('\n')}</pre>
+              </details>
+            )}
           </div>
-          {props.saveAndVerifyReport.technicalDetails.length > 0 && (
-            <details>
-              <summary>技术详情</summary>
-              <pre>{props.saveAndVerifyReport.technicalDetails.join('\n')}</pre>
-            </details>
-          )}
-        </section>
+        </details>
       )}
-      {page}
     </div>
   );
 }

--- a/src/components/settings/AiServiceSettings.test.tsx
+++ b/src/components/settings/AiServiceSettings.test.tsx
@@ -13,10 +13,11 @@ describe('AiServiceSettings', () => {
     window.localStorage.clear();
   });
 
-  it('shows friendly service type labels and MCP client section', () => {
+  it('shows compact AI sections and service type labels', () => {
     render(<AiServiceSettings />);
-    expect(screen.getByText(/模型推理服务 \(LLM\)/)).not.toBeNull();
-    expect(screen.getByText(/MCP 服务 \(Model Context Protocol\)/)).not.toBeNull();
+    expect(screen.getByText('AI 功能')).not.toBeNull();
+    expect(screen.getByText('服务与模型')).not.toBeNull();
+    expect(screen.getByRole('combobox').textContent).toContain('OpenAI 兼容服务');
   });
 
   it('allows MCP to be selected as the active inference engine', () => {
@@ -28,53 +29,59 @@ describe('AiServiceSettings', () => {
       privacyAcknowledged: true,
     });
     render(<AiServiceSettings />);
-    expect(screen.getByRole('combobox').textContent).toContain('MCP 服务器');
+    expect(screen.getByRole('combobox').textContent).toContain('MCP 服务');
     expect(screen.getByDisplayValue('http://127.0.0.1:8080/mcp')).not.toBeNull();
-    expect(screen.getByText('Bearer 鉴权 Token')).not.toBeNull();
-    expect(screen.getByText(/当前已选择 MCP 服务器作为推理引擎/)).not.toBeNull();
+    expect(screen.getByText('访问 Token')).not.toBeNull();
+    expect(screen.getByText('服务与模型')).not.toBeNull();
   });
 
   it('offers MCP in the inference engine selector', () => {
     seedConfig({ enabled: true, serviceType: 'http', endpoint: 'https://api.example.com/v1' });
     render(<AiServiceSettings />);
     fireEvent.click(screen.getByRole('combobox'));
-    expect(screen.getByRole('option', { name: /MCP 服务器/ })).not.toBeNull();
+    expect(screen.getByRole('option', { name: /MCP 服务/ })).not.toBeNull();
   });
 
   it('configures MCP as a client endpoint rather than a local gateway', () => {
+    seedConfig({
+      enabled: true,
+      serviceType: 'mcp',
+      mcpEndpoint: 'http://127.0.0.1:8080/mcp',
+      privacyAcknowledged: true,
+    });
     render(<AiServiceSettings />);
     // 不再宣称本地暴露 MCP HTTP 服务（无 listener）。
     expect(screen.queryByText('开启 MCP 网关服务')).toBeNull();
     expect(screen.queryByText(/本地暴露/)).toBeNull();
     expect(screen.queryByText('MCP 网关地址')).toBeNull();
-    // 保留实际存在的 MCP 客户端能力配置。
-    expect(screen.getByText('启用 MCP 服务')).not.toBeNull();
-    expect(screen.getByText(/连接外部 MCP 服务器/)).not.toBeNull();
+    // 保留实际存在的 MCP 客户端端点配置。
+    expect(screen.getByText('MCP 服务端点')).not.toBeNull();
+    expect(screen.getByText('访问 Token')).not.toBeNull();
   });
 
   it('shows the status with 未启用 when the service is off', () => {
     seedConfig({ enabled: false, serviceType: 'http' });
     render(<AiServiceSettings />);
     expect(screen.getByText('未启用')).not.toBeNull();
-    expect(screen.getAllByText(/可用功能：翻译、摘要、模板生成/).length).toBeGreaterThanOrEqual(1);
+    expect(screen.getByText('用于翻译、摘要、模板生成。')).not.toBeNull();
   });
 
   it('shows 本地演示 status and no external privacy confirmation in mock mode', () => {
     seedConfig({ enabled: true, serviceType: 'mock' });
     render(<AiServiceSettings />);
-    expect(screen.getByText('本地演示')).not.toBeNull();
+    expect(screen.getAllByText('本地演示').length).toBeGreaterThanOrEqual(1);
     expect(screen.queryByText('隐私确认')).toBeNull();
     expect(screen.queryByText(/我已阅读并同意将邮件内容发送到外部 AI 服务/)).toBeNull();
-    expect(screen.getAllByText(/不会向任何外部服务器发送内容/).length).toBeGreaterThanOrEqual(1);
-    expect(screen.getAllByText(/本地模拟服务/).length).toBeGreaterThanOrEqual(1);
+    expect(screen.getByText('本地演示不会向外部服务器发送邮件内容。')).not.toBeNull();
+    expect(screen.getByText('返回稳定的示例结果，不需要网络、密钥或隐私授权。')).not.toBeNull();
   });
 
   it('shows the privacy confirmation area for external service modes', () => {
     seedConfig({ enabled: true, serviceType: 'http', endpoint: 'https://api.example.com/v1' });
     render(<AiServiceSettings />);
-    expect(screen.getByText('隐私确认')).not.toBeNull();
-    expect(screen.getByText(/我已阅读并同意将邮件内容发送到外部 AI 服务/)).not.toBeNull();
-    expect(screen.getByText(/邮件正文或提示词可能发送到配置的服务/)).not.toBeNull();
+    expect(screen.getByText('外部服务隐私')).not.toBeNull();
+    expect(screen.getByText('允许向此服务发送邮件内容')).not.toBeNull();
+    expect(screen.getByText(/相关邮件内容与提示词会发送到你配置的服务/)).not.toBeNull();
   });
 
   it('keeps test connection and save actions available', () => {

--- a/src/components/settings/AiServiceSettings.tsx
+++ b/src/components/settings/AiServiceSettings.tsx
@@ -1,11 +1,10 @@
 import {
   CheckCircle2,
   FlaskConical,
-  Globe,
   KeyRound,
   PlugZap,
+  Save,
   ShieldAlert,
-  Sparkles,
   XCircle,
 } from 'lucide-react';
 import type { AiServiceType } from '../../app/types/ai';
@@ -33,6 +32,7 @@ export default function AiServiceSettings() {
     saveConfig,
     runTestConnection,
   } = useAiService({ setStatus: () => undefined });
+
   const isMcp = config.serviceType === 'mcp';
   const external = config.serviceType !== 'mock';
   const providerEndpoint = isMcp ? config.mcpEndpoint ?? '' : config.endpoint;
@@ -43,63 +43,41 @@ export default function AiServiceSettings() {
     : config.serviceType === 'mock'
       ? '本地演示'
       : config.serviceType === 'mcp'
-        ? 'MCP 服务'
-        : '外部 API';
+        ? 'MCP'
+        : '外部服务';
 
   return (
     <div className="settings-ai-page-stack">
-      {/* 模块一：AI 服务状态 */}
       <SettingsSection
-        title="AI 服务"
-        description={`可用功能：${AVAILABLE_FEATURES.join('、')}。`}
-        badge={<span className="st-badge st-badge-info">{statusLabel}</span>}
+        title="AI 功能"
+        description={`用于${AVAILABLE_FEATURES.join('、')}。`}
+        badge={<SettingsBadge tone={config.enabled ? 'info' : 'neutral'}>{statusLabel}</SettingsBadge>}
         dataSection="ai"
       >
-        <div className="ai-hero-card">
-          <div className="ai-overview-row" aria-label="AI 服务状态">
-            <span className="ai-overview-icon" aria-hidden="true"><Sparkles size={16} /></span>
-            <span className="ai-overview-copy">
-              <strong>可用功能：{AVAILABLE_FEATURES.join('、')}。</strong>
-              <small>
-                {external
-                  ? '启用外部服务后，邮件正文或提示词可能发送到配置的服务。'
-                  : '本地演示模式不会向任何外部服务器发送内容。'}
-              </small>
-            </span>
-          </div>
-
-          <div className="ai-hero-toggle-row">
-            <SettingsSwitch
-              label="启用 AI 服务"
-              description="启用翻译、摘要与模板生成功能。配置数据会安全保留。"
-              checked={config.enabled}
-              onChange={(checked) => patchConfig({ enabled: checked })}
-            />
-          </div>
-        </div>
+        <SettingsSwitch
+          label="启用 AI 功能"
+          description={external
+            ? '使用时，邮件内容可能会发送到你配置的外部服务。'
+            : '本地演示不会向外部服务器发送邮件内容。'}
+          checked={config.enabled}
+          onChange={(checked) => patchConfig({ enabled: checked })}
+        />
       </SettingsSection>
 
-      {/* 核心服务区域 */}
       <div className={`settings-ai-config-area${config.enabled ? '' : ' is-dimmed'}`}>
-        {/* 模块二：LLM 模型推理服务配置 */}
         <SettingsSection
-          title="模型推理服务 (LLM)"
-          description="用于处理应用内的邮件翻译、摘要与模板生成"
-          badge={
-            <SettingsBadge tone={external ? 'info' : 'neutral'}>
-              {external ? '外部 API 引擎' : '本地演示模式'}
-            </SettingsBadge>
-          }
+          title="服务与模型"
+          description="选择 Better Email 如何处理 AI 请求。"
           dataSection="ai-llm-provider"
         >
-          <SettingsField label="选择推理引擎来源" hint="按需选择本地离线演示模式、OpenAI 兼容 API 或 MCP 服务器">
+          <SettingsField label="AI 服务">
             <CustomSelect
               dense
               value={config.serviceType}
               options={[
-                { value: 'mock', label: '本地演示模式 (Mock) — 离线示例，无外部请求' },
-                { value: 'http', label: 'OpenAI 兼容 API — 连接兼容 chat/completions 的外部 LLM 服务' },
-                { value: 'mcp', label: 'MCP 服务器 — 通过 JSON-RPC 调用外部工具' },
+                { value: 'mock', label: '本地演示' },
+                { value: 'http', label: 'OpenAI 兼容服务' },
+                { value: 'mcp', label: 'MCP 服务' },
               ]}
               onChange={(val) => {
                 const nextServiceType = val as AiServiceType;
@@ -111,116 +89,125 @@ export default function AiServiceSettings() {
             />
           </SettingsField>
 
+          {!isMcp && external && (
+            <SettingsField label="模型" hint="填写服务支持的模型名称">
+              <input
+                className="settings-text-input"
+                type="text"
+                placeholder="gpt-4o-mini"
+                value={config.defaultModel}
+                onChange={(event) => patchConfig({ defaultModel: event.target.value })}
+              />
+            </SettingsField>
+          )}
+
           {external && (
-            <div className="st-field-grid" style={{ marginTop: '16px' }}>
-              <SettingsField label={isMcp ? 'MCP 服务端点' : 'API 服务端点'}>
-                <input
-                  className="settings-text-input"
-                  type="url"
-                  placeholder={isMcp ? 'http://127.0.0.1:8080/mcp' : 'https://api.example.com/v1'}
-                  value={providerEndpoint}
-                  onChange={(event) => patchConfig(isMcp
-                    ? { mcpEndpoint: event.target.value }
-                    : { endpoint: event.target.value })}
-                />
-              </SettingsField>
+            <>
+              <SettingsNotice tone="warning" title="外部服务隐私" icon={ShieldAlert}>
+                <p>翻译、摘要或模板生成时，相关邮件内容与提示词会发送到你配置的服务。</p>
+              </SettingsNotice>
+              <SettingsSwitch
+                label="允许向此服务发送邮件内容"
+                description="确认后才能使用外部 AI 服务。"
+                checked={config.privacyAcknowledged}
+                onChange={(checked) => patchConfig({ privacyAcknowledged: checked })}
+              />
 
-              <SettingsField label={isMcp ? 'Bearer 鉴权 Token' : 'API Key / Token'}>
-                <div className="settings-ai-key-row">
-                  <input
-                    className="settings-text-input"
-                    type="password"
-                    placeholder={providerHasApiKey
-                      ? `已保存${isMcp ? ' Token' : ' Key'}，留空保持不变`
-                      : isMcp ? '输入访问 MCP 服务的 Token' : '输入 API Key'}
-                    value={providerApiKey}
-                    onChange={(event) => patchConfig(isMcp
-                      ? { mcpApiKey: event.target.value }
-                      : { apiKey: event.target.value })}
-                    autoComplete="off"
-                  />
-                  {providerHasApiKey && !providerApiKey ? (
-                    <button
-                      type="button"
-                      className="settings-text-button"
-                      onClick={() => patchConfig(isMcp
-                        ? { clearMcpApiKey: true, hasMcpApiKey: false }
-                        : { clearApiKey: true, hasApiKey: false })}
-                    >
-                      清除已保存{isMcp ? ' Token' : ' Key'}
-                    </button>
-                  ) : (
-                    <span className="settings-ai-key-hint">
-                      <KeyRound size={12} aria-hidden="true" />
-                      {providerHasApiKey ? `已保存${isMcp ? ' Token' : ' Key'}` : '未保存'}
-                    </span>
-                  )}
+              <details
+                className="settings-disclosure settings-ai-advanced"
+                data-settings-section="ai-advanced"
+              >
+                <summary>
+                  <span>
+                    <strong>高级连接</strong>
+                    <small>端点、密钥与超时时间</small>
+                  </span>
+                  <em>{providerEndpoint ? '已配置' : '待配置'}</em>
+                </summary>
+                <div className="settings-disclosure-body st-field-grid">
+                  <SettingsField label={isMcp ? 'MCP 服务端点' : 'API 服务端点'}>
+                    <input
+                      className="settings-text-input"
+                      type="url"
+                      placeholder={isMcp ? 'http://127.0.0.1:8080/mcp' : 'https://api.example.com/v1'}
+                      value={providerEndpoint}
+                      onChange={(event) => patchConfig(isMcp
+                        ? { mcpEndpoint: event.target.value }
+                        : { endpoint: event.target.value })}
+                    />
+                  </SettingsField>
+
+                  <SettingsField label={isMcp ? '访问 Token' : 'API Key / Token'}>
+                    <div className="settings-ai-key-row">
+                      <input
+                        className="settings-text-input"
+                        type="password"
+                        placeholder={providerHasApiKey
+                          ? '已保存，留空保持不变'
+                          : '输入访问密钥'}
+                        value={providerApiKey}
+                        onChange={(event) => patchConfig(isMcp
+                          ? { mcpApiKey: event.target.value }
+                          : { apiKey: event.target.value })}
+                        autoComplete="off"
+                      />
+                      {providerHasApiKey && !providerApiKey ? (
+                        <button
+                          type="button"
+                          className="settings-text-button"
+                          onClick={() => patchConfig(isMcp
+                            ? { clearMcpApiKey: true, hasMcpApiKey: false }
+                            : { clearApiKey: true, hasApiKey: false })}
+                        >
+                          清除已保存密钥
+                        </button>
+                      ) : (
+                        <span className="settings-ai-key-hint">
+                          <KeyRound size={12} aria-hidden="true" />
+                          {providerHasApiKey ? '已保存' : '未保存'}
+                        </span>
+                      )}
+                    </div>
+                  </SettingsField>
+
+                  <SettingsField label="请求超时" hint="5–300 秒">
+                    <input
+                      className="settings-text-input"
+                      type="number"
+                      min={5}
+                      max={300}
+                      value={config.timeoutSeconds}
+                      onChange={(event) => patchConfig({ timeoutSeconds: Number(event.target.value) || 30 })}
+                    />
+                  </SettingsField>
                 </div>
-              </SettingsField>
-
-              {!isMcp && (
-                <SettingsField label="默认模型名称">
-                  <input
-                    className="settings-text-input"
-                    type="text"
-                    placeholder="gpt-4o-mini"
-                    value={config.defaultModel}
-                    onChange={(event) => patchConfig({ defaultModel: event.target.value })}
-                  />
-                </SettingsField>
-              )}
-
-              <SettingsField label="请求超时时间 (秒)">
-                <input
-                  className="settings-text-input"
-                  type="number"
-                  min={5}
-                  max={300}
-                  value={config.timeoutSeconds}
-                  onChange={(event) => patchConfig({ timeoutSeconds: Number(event.target.value) || 30 })}
-                />
-              </SettingsField>
-
-              <div style={{ gridColumn: '1 / -1' }}>
-                <SettingsNotice tone="warning" title="隐私确认" icon={ShieldAlert}>
-                  <p>
-                    开启翻译、模板生成或摘要后，邮件正文与提示词将被发送到上面配置的外部服务。
-                    请在确认服务商数据处理政策后使用；Better Email 不会在你的设备之外保存这些内容。
-                  </p>
-                  <SettingsSwitch
-                    label={`我已阅读并同意将邮件内容发送到外部${isMcp ? ' MCP 服务' : ' AI 服务'}`}
-                    description="未确认前，外部服务模式无法使用翻译、摘要与模板生成。"
-                    checked={config.privacyAcknowledged}
-                    onChange={(checked) => patchConfig({ privacyAcknowledged: checked })}
-                  />
-                </SettingsNotice>
-              </div>
-            </div>
+              </details>
+            </>
           )}
 
           {!external && (
-            <SettingsNotice tone="info" title="本地演示模式" icon={FlaskConical} style={{ marginTop: '12px' }}>
-              <p>
-                当前为本地模拟服务：翻译、模板生成与摘要返回稳定的示例结果，
-                不会向任何外部服务器发送内容，无需网络连接，也不需要隐私确认。
-              </p>
+            <SettingsNotice tone="info" title="本地演示" icon={FlaskConical}>
+              <p>返回稳定的示例结果，不需要网络、密钥或隐私授权。</p>
             </SettingsNotice>
           )}
 
-          <div className="st-actions" style={{ marginTop: '16px', paddingTop: '16px', borderTop: '1px solid var(--st-border)' }}>
+          <div className="st-actions settings-ai-actions">
             <SettingsButton onClick={runTestConnection} disabled={testing || !config.enabled}>
               <PlugZap size={14} />
               {testing ? '测试中…' : '测试连接'}
             </SettingsButton>
-            <SettingsButton variant="primary" onClick={() => { saveConfig().catch(() => undefined); }} disabled={saving}>
-              <Globe size={14} />
+            <SettingsButton
+              variant="primary"
+              onClick={() => { saveConfig().catch(() => undefined); }}
+              disabled={saving}
+            >
+              <Save size={14} />
               {saving ? '保存中…' : '保存设置'}
             </SettingsButton>
           </div>
+
           {saveError && (
-            <p className="settings-ai-save-error" role="alert">
-              {saveError}
-            </p>
+            <p className="settings-ai-save-error" role="alert">{saveError}</p>
           )}
 
           {testResult && (
@@ -231,71 +218,6 @@ export default function AiServiceSettings() {
                 <em>{testResult.latencyMs} ms</em>
               )}
             </div>
-          )}
-        </SettingsSection>
-
-        {/* 模块四：MCP (Model Context Protocol) 客户端配置 */}
-        <SettingsSection
-          title="MCP 服务 (Model Context Protocol)"
-          description="连接外部 MCP 服务器，通过 JSON-RPC 调用翻译、摘要与模板生成工具"
-          badge={
-            <SettingsBadge tone={config.mcpEnabled ? 'success' : 'neutral'}>
-              {config.mcpEnabled ? 'MCP 已启用' : 'MCP 未启用'}
-            </SettingsBadge>
-          }
-          dataSection="ai-mcp-gateway"
-        >
-          <SettingsSwitch
-            label="启用 MCP 服务"
-            description="启用后，应用可调用已配置的 MCP 服务器执行翻译、摘要与模板生成。"
-            checked={Boolean(config.mcpEnabled)}
-            onChange={(checked) => patchConfig({ mcpEnabled: checked })}
-          />
-
-          {config.mcpEnabled && !isMcp && (
-            <div className="st-field-grid" style={{ marginTop: '12px' }}>
-              <SettingsField label="MCP 服务端点">
-                <input
-                  className="settings-text-input"
-                  type="url"
-                  placeholder="http://127.0.0.1:8080/mcp"
-                  value={config.mcpEndpoint || ''}
-                  onChange={(event) => patchConfig({ mcpEndpoint: event.target.value })}
-                />
-              </SettingsField>
-
-              <SettingsField label="Bearer 鉴权 Token (可选)">
-                <div className="settings-ai-key-row">
-                  <input
-                    className="settings-text-input"
-                    type="password"
-                    placeholder={config.hasMcpApiKey ? '已保存 Token，留空保持不变' : '设置访问该服务的鉴权 Token (Bearer)'}
-                    value={config.mcpApiKey || ''}
-                    onChange={(event) => patchConfig({ mcpApiKey: event.target.value })}
-                    autoComplete="off"
-                  />
-                  {config.hasMcpApiKey && !config.mcpApiKey ? (
-                    <button
-                      type="button"
-                      className="settings-text-button"
-                      onClick={() => patchConfig({ clearMcpApiKey: true, hasMcpApiKey: false })}
-                    >
-                      清除已保存 Token
-                    </button>
-                  ) : (
-                    <span className="settings-ai-key-hint">
-                      <KeyRound size={12} aria-hidden="true" />
-                      {config.hasMcpApiKey ? '已保存 Token' : ''}
-                    </span>
-                  )}
-                </div>
-              </SettingsField>
-            </div>
-          )}
-          {config.mcpEnabled && isMcp && (
-            <SettingsNotice tone="info" title="当前推理引擎" icon={PlugZap} style={{ marginTop: '12px' }}>
-              <p>当前已选择 MCP 服务器作为推理引擎；端点和 Token 请在上方模型推理服务区域配置。</p>
-            </SettingsNotice>
           )}
         </SettingsSection>
       </div>

--- a/src/components/settings/AppearanceSettings.test.tsx
+++ b/src/components/settings/AppearanceSettings.test.tsx
@@ -5,14 +5,14 @@ import AppearanceSettings from './AppearanceSettings';
 describe('AppearanceSettings', () => {
   afterEach(cleanup);
 
-  it('renders a radio group with option descriptions and automatic-save status', () => {
+  it('renders a radio group with compact option descriptions', () => {
     render(<AppearanceSettings themeMode="dark" onThemeModeChange={vi.fn()} />);
 
     const group = screen.getByRole('radiogroup', { name: '界面外观' });
     expect(group.querySelectorAll('[role="radio"]')).toHaveLength(3);
-    expect(screen.getByRole('radio', { name: /^暗色：/ }).getAttribute('aria-checked')).toBe('true');
-    expect(screen.getByText('始终使用深色的界面外观。')).toBeDefined();
-    expect(screen.getByText('当前使用“暗色”，更改已自动保存。')).toBeDefined();
+    expect(screen.getByRole('radio', { name: '深色：始终使用深色界面' }).getAttribute('aria-checked')).toBe('true');
+    expect(screen.getByRole('radio', { name: '浅色：始终使用浅色界面' }).getAttribute('title')).toBe('始终使用浅色界面');
+    expect(screen.getByText('选择最适合当前环境的界面。')).toBeDefined();
   });
 
   it('changes the selection with arrow keys and moves focus to the next option', () => {
@@ -22,7 +22,7 @@ describe('AppearanceSettings', () => {
     const group = screen.getByRole('radiogroup', { name: '界面外观' });
     fireEvent.keyDown(group, { key: 'ArrowRight' });
 
-    const lightOption = screen.getByRole('radio', { name: /^亮色：/ });
+    const lightOption = screen.getByRole('radio', { name: '浅色：始终使用浅色界面' });
     expect(onThemeModeChange).toHaveBeenCalledWith('light');
     expect(document.activeElement).toBe(lightOption);
   });

--- a/src/components/settings/AppearanceSettings.tsx
+++ b/src/components/settings/AppearanceSettings.tsx
@@ -16,20 +16,20 @@ const themeOptions: Array<{
 }> = [
   {
     value: 'system',
-    label: '跟随系统',
-    description: '根据操作系统的外观设置自动切换亮色与暗色。',
+    label: '系统',
+    description: '跟随操作系统自动切换亮色与暗色',
     icon: Monitor,
   },
   {
     value: 'light',
-    label: '亮色',
-    description: '始终使用明亮的界面外观。',
+    label: '浅色',
+    description: '始终使用浅色界面',
     icon: Sun,
   },
   {
     value: 'dark',
-    label: '暗色',
-    description: '始终使用深色的界面外观。',
+    label: '深色',
+    description: '始终使用深色界面',
     icon: Moon,
   },
 ];
@@ -38,8 +38,6 @@ export default function AppearanceSettings({
   themeMode,
   onThemeModeChange,
 }: AppearanceSettingsProps) {
-  const selectedOption = themeOptions.find((option) => option.value === themeMode) ?? themeOptions[0];
-
   const handleOptionKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
     const currentIndex = themeOptions.findIndex((option) => option.value === themeMode);
     let nextIndex = currentIndex;
@@ -70,47 +68,52 @@ export default function AppearanceSettings({
   };
 
   return (
-    <SettingsSection className="settings-appearance-section" dataSection="appearance">
-      <div className="settings-theme-preference">
-        <div
-          className="settings-theme-options"
-          role="radiogroup"
-          aria-label="界面外观"
-          aria-describedby="settings-theme-description"
-          onKeyDown={handleOptionKeyDown}
-        >
-          {themeOptions.map((option) => {
-            const Icon = option.icon;
-            const active = themeMode === option.value;
-            return (
-              <button
-                key={option.value}
-                type="button"
-                className={active ? 'settings-theme-option active' : 'settings-theme-option'}
-                role="radio"
-                aria-checked={active}
-                tabIndex={active ? 0 : -1}
-                aria-label={`${option.label}：${option.description}`}
-                data-theme-mode={option.value}
-                title={option.description}
-                onClick={() => onThemeModeChange(option.value)}
-              >
-                <span className="settings-theme-option-icon" aria-hidden="true">
-                  <Icon size={17} />
+    <SettingsSection
+      title="外观"
+      description="选择最适合当前环境的界面。"
+      className="settings-appearance-section"
+      dataSection="appearance"
+    >
+      <div
+        className="settings-theme-options"
+        role="radiogroup"
+        aria-label="界面外观"
+        onKeyDown={handleOptionKeyDown}
+      >
+        {themeOptions.map((option) => {
+          const Icon = option.icon;
+          const active = themeMode === option.value;
+          return (
+            <button
+              key={option.value}
+              type="button"
+              className={active ? 'settings-theme-option active' : 'settings-theme-option'}
+              role="radio"
+              aria-checked={active}
+              tabIndex={active ? 0 : -1}
+              aria-label={`${option.label}：${option.description}`}
+              data-theme-mode={option.value}
+              title={option.description}
+              onClick={() => onThemeModeChange(option.value)}
+            >
+              <span className="settings-theme-option-preview" aria-hidden="true">
+                <span className="settings-theme-preview-sidebar" />
+                <span className="settings-theme-preview-content">
+                  <i />
+                  <i />
+                  <i />
                 </span>
-                <span className="settings-theme-option-copy">
+              </span>
+              <span className="settings-theme-option-footer">
+                <span>
+                  <Icon size={15} aria-hidden="true" />
                   <strong>{option.label}</strong>
-                  <small>{option.description}</small>
                 </span>
-                <Check className="settings-theme-option-check" aria-hidden="true" size={17} />
-              </button>
-            );
-          })}
-        </div>
-        <p id="settings-theme-description" className="settings-theme-description" aria-live="polite">
-          <Check aria-hidden="true" size={14} />
-          <span>当前使用“{selectedOption.label}”，更改已自动保存。</span>
-        </p>
+                <Check className="settings-theme-option-check" aria-hidden="true" size={15} />
+              </span>
+            </button>
+          );
+        })}
       </div>
     </SettingsSection>
   );

--- a/src/components/settings/DataSafetySettings.tsx
+++ b/src/components/settings/DataSafetySettings.tsx
@@ -295,26 +295,28 @@ export default function DataSafetySettings({
       )}
 
       {devMode && connectionReport && (
-        <SettingsSection
-          title="服务器连接"
-          description="开发模式：仅检查 IMAP、SMTP 网络端点，不验证账号凭据"
-          badge={
-            <SettingsBadge tone="neutral">
-              {connectionReport.endpoints.filter((endpoint) => endpoint.reachable).length}/{connectionReport.endpoints.length} 可用
-            </SettingsBadge>
-          }
-        >
-          <div className="settings-endpoint-grid">
-            {connectionReport.endpoints.map((endpoint) => (
-              <div className={endpoint.reachable ? 'st-data-row ok' : 'st-data-row warn'} key={endpoint.name}>
-                <span>{endpoint.name}</span>
-                <em>{endpoint.address}</em>
-                <small>{endpoint.latency_ms === null ? '未连通' : `${endpoint.latency_ms}ms`}</small>
-                <p>{endpoint.message}</p>
-              </div>
-            ))}
-          </div>
-        </SettingsSection>
+        <div className="settings-developer-diagnostics">
+          <SettingsSection
+            title="服务器连接"
+            description="开发模式：仅检查 IMAP、SMTP 网络端点，不验证账号凭据"
+            badge={
+              <SettingsBadge tone="neutral">
+                {connectionReport.endpoints.filter((endpoint) => endpoint.reachable).length}/{connectionReport.endpoints.length} 可用
+              </SettingsBadge>
+            }
+          >
+            <div className="settings-endpoint-grid">
+              {connectionReport.endpoints.map((endpoint) => (
+                <div className={endpoint.reachable ? 'st-data-row ok' : 'st-data-row warn'} key={endpoint.name}>
+                  <span>{endpoint.name}</span>
+                  <em>{endpoint.address}</em>
+                  <small>{endpoint.latency_ms === null ? '未连通' : `${endpoint.latency_ms}ms`}</small>
+                  <p>{endpoint.message}</p>
+                </div>
+              ))}
+            </div>
+          </SettingsSection>
+        </div>
       )}
 
       {cacheConfirmationOpen && storageUsage && createPortal((

--- a/src/components/settings/DataSafetySettings.tsx
+++ b/src/components/settings/DataSafetySettings.tsx
@@ -23,6 +23,7 @@ import type {
 } from '../../app/types';
 import { formatBytes } from '../../mailUtils';
 import { copyTextToClipboard } from '../../app/clipboard';
+import { devMode } from './settingsNavigation';
 import {
   SettingsBadge,
   SettingsButton,
@@ -77,8 +78,6 @@ export default function DataSafetySettings({
     if (copyTimerRef.current) clearTimeout(copyTimerRef.current);
   }, []);
 
-  // 嵌套缓存确认对话框拥有 Escape：在 document 冒泡阶段 stopPropagation，
-  // SettingsFrame 的 window 级 Escape 不会把整个设置页一起关闭。
   useEffect(() => {
     if (!cacheConfirmationOpen) return undefined;
     const previouslyFocused = document.activeElement;
@@ -185,9 +184,7 @@ export default function DataSafetySettings({
                 ? `${storageUsage.cached_attachment_count} 个远端附件 · ${storageUsage.partial_download_count} 个断点文件`
                 : '正在读取附件缓存'}
             </strong>
-            <small>
-              清理后远端附件可再次下载；导入 EML 和本地唯一附件不会删除。
-            </small>
+            <small>清理后远端附件可再次下载；导入 EML 和本地唯一附件不会删除。</small>
           </span>
           <SettingsButton
             variant="danger-secondary"
@@ -249,9 +246,7 @@ export default function DataSafetySettings({
               : '手动下载与自动下载的新附件都会保存到该文件夹。'}
           </p>
           {downloadDirError && (
-            <p className="settings-download-error" role="alert">
-              {downloadDirError}
-            </p>
+            <p className="settings-download-error" role="alert">{downloadDirError}</p>
           )}
         </div>
       </SettingsSection>
@@ -299,10 +294,10 @@ export default function DataSafetySettings({
         </SettingsSection>
       )}
 
-      {connectionReport && (
+      {devMode && connectionReport && (
         <SettingsSection
           title="服务器连接"
-          description="仅检查 IMAP、SMTP 网络端点，不验证账号凭据"
+          description="开发模式：仅检查 IMAP、SMTP 网络端点，不验证账号凭据"
           badge={
             <SettingsBadge tone="neutral">
               {connectionReport.endpoints.filter((endpoint) => endpoint.reachable).length}/{connectionReport.endpoints.length} 可用

--- a/src/components/settings/SettingsFrame.test.tsx
+++ b/src/components/settings/SettingsFrame.test.tsx
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import SettingsFrame from './SettingsFrame';
 
 describe('SettingsFrame dialog behavior', () => {
@@ -75,8 +75,8 @@ describe('SettingsFrame dialog behavior', () => {
 
   it('disables account detail tabs when no account exists', () => {
     renderFrame({ activeSection: 'accounts', canSaveAndVerify: false });
-    expect(screen.getByRole('button', { name: '服务器' })).toBeDisabled();
-    expect(screen.getByRole('button', { name: '概览' })).not.toBeDisabled();
+    expect((screen.getByRole('button', { name: '服务器' }) as HTMLButtonElement).disabled).toBe(true);
+    expect((screen.getByRole('button', { name: '概览' }) as HTMLButtonElement).disabled).toBe(false);
   });
 
   it('marks background siblings inert and aria-hidden while open', () => {
@@ -197,7 +197,7 @@ describe('SettingsFrame dialog behavior', () => {
     expect(document.querySelector('.settings-floating-unsaved-bar')).toBeNull();
     fireEvent.click(saveActions[0]);
     expect(onSave).toHaveBeenCalledTimes(1);
-    expect(screen.queryByRole('button', { name: '测试连接' })).toBeNull();
+    expect(screen.queryByRole('button', { name: '测试连接' })).not.toBeNull();
   });
 
   it('offers connection testing when the active connection page is clean', () => {
@@ -212,11 +212,11 @@ describe('SettingsFrame dialog behavior', () => {
     expect(screen.queryByRole('button', { name: '保存账号设置' })).toBeNull();
   });
 
-  it('uses one General navigation entry with inner appearance and sending tabs', () => {
+  it('keeps sending as a direct top-level navigation entry', () => {
     const onNavigate = vi.fn();
     renderFrame({ activeSection: 'sending', onNavigate });
-    const tabs = screen.getByRole('navigation', { name: '通用设置分类' });
-    fireEvent.click(within(tabs).getByRole('button', { name: '外观' }));
+    expect(screen.getByRole('button', { name: '发送设置' }).getAttribute('aria-current')).toBe('page');
+    fireEvent.click(screen.getByRole('button', { name: '通用设置' }));
     expect(onNavigate).toHaveBeenCalledWith('appearance');
   });
 });

--- a/src/components/settings/SettingsFrame.tsx
+++ b/src/components/settings/SettingsFrame.tsx
@@ -7,6 +7,7 @@ import {
   X,
 } from 'lucide-react';
 import SettingsPageShell from './SettingsPageShell';
+import { CustomSelect } from './accounts/CustomSelect';
 import useModalAccessibility from '../../hooks/useModalAccessibility';
 import {
   SettingsMobileNavigation,
@@ -105,21 +106,23 @@ function SettingsAccountWorkspace({
     <div className="settings-account-workspace">
       <div className="settings-account-workspace-topline">
         {canSwitchAccount ? (
-          <label className="settings-account-picker">
+          <label
+            className="settings-account-picker"
+            title={accountSwitchDisabled ? '请先保存或放弃当前账号的修改' : '切换当前设置账号'}
+          >
             <span>当前账号</span>
-            <select
-              aria-label="切换当前设置账号"
-              value={activeAccountId ?? ''}
+            <CustomSelect
+              dense
+              ariaLabel="切换当前设置账号"
+              value={String(activeAccountId ?? '')}
+              options={accountOptions.map((account) => ({
+                value: String(account.id),
+                label: account.label,
+                meta: account.email,
+              }))}
               disabled={accountSwitchDisabled}
-              title={accountSwitchDisabled ? '请先保存或放弃当前账号的修改' : '切换当前设置账号'}
-              onChange={(event) => onSelectAccountId?.(Number(event.target.value))}
-            >
-              {accountOptions.map((account) => (
-                <option value={account.id} key={account.id}>
-                  {account.label} · {account.email}
-                </option>
-              ))}
-            </select>
+              onChange={(nextValue) => onSelectAccountId?.(Number(nextValue))}
+            />
           </label>
         ) : (
           <span className="settings-account-current">

--- a/src/components/settings/SettingsFrame.tsx
+++ b/src/components/settings/SettingsFrame.tsx
@@ -35,6 +35,7 @@ type SettingsAccountOption = {
 
 type SettingsFrameProps = {
   title: string;
+  subtitle?: string;
   activeSection: SettingsSectionId;
   children: React.ReactNode;
   onNavigate: (section: SettingsSectionId) => void;
@@ -76,6 +77,7 @@ const accountWorkspaceTabs: Array<{ id: SettingsSectionId; label: string }> = [
 function SettingsAccountWorkspace({
   activeSection,
   canUseAccountTabs,
+  currentAccountLabel,
   accountOptions,
   activeAccountId,
   connectionSummary,
@@ -84,6 +86,7 @@ function SettingsAccountWorkspace({
 }: {
   activeSection: SettingsSectionId;
   canUseAccountTabs: boolean;
+  currentAccountLabel: string;
   accountOptions: SettingsAccountOption[];
   activeAccountId: number | null;
   connectionSummary?: string;
@@ -94,27 +97,32 @@ function SettingsAccountWorkspace({
 
   const hasConnectionSummary = Boolean(connectionSummary)
     && connectionSummary !== '尚未开始验证';
+  const canSwitchAccount = accountOptions.length > 0 && Boolean(onSelectAccountId);
 
   return (
     <div className="settings-account-workspace">
       <div className="settings-account-workspace-topline">
-        <label className="settings-account-picker">
-          <span>当前账号</span>
-          <select
-            aria-label="切换当前设置账号"
-            value={activeAccountId ?? ''}
-            disabled={accountOptions.length === 0 || !onSelectAccountId}
-            onChange={(event) => onSelectAccountId?.(Number(event.target.value))}
-          >
-            {accountOptions.length === 0 ? (
-              <option value="">尚未添加账号</option>
-            ) : accountOptions.map((account) => (
-              <option value={account.id} key={account.id}>
-                {account.label} · {account.email}
-              </option>
-            ))}
-          </select>
-        </label>
+        {canSwitchAccount ? (
+          <label className="settings-account-picker">
+            <span>当前账号</span>
+            <select
+              aria-label="切换当前设置账号"
+              value={activeAccountId ?? ''}
+              onChange={(event) => onSelectAccountId?.(Number(event.target.value))}
+            >
+              {accountOptions.map((account) => (
+                <option value={account.id} key={account.id}>
+                  {account.label} · {account.email}
+                </option>
+              ))}
+            </select>
+          </label>
+        ) : (
+          <span className="settings-account-current">
+            <small>当前账号</small>
+            <strong>{currentAccountLabel || '尚未添加账号'}</strong>
+          </span>
+        )}
         {hasConnectionSummary && (
           <span className="settings-account-connection-state" title={connectionSummary}>
             {connectionSummary}
@@ -145,6 +153,7 @@ function SettingsAccountWorkspace({
 
 export default function SettingsFrame({
   title,
+  subtitle = '',
   activeSection,
   children,
   onNavigate,
@@ -304,6 +313,7 @@ export default function SettingsFrame({
             <SettingsAccountWorkspace
               activeSection={activeSection}
               canUseAccountTabs={canSaveAndVerify}
+              currentAccountLabel={subtitle}
               accountOptions={accountOptions}
               activeAccountId={activeAccountId}
               connectionSummary={connectionSummary}

--- a/src/components/settings/SettingsFrame.tsx
+++ b/src/components/settings/SettingsFrame.tsx
@@ -77,6 +77,7 @@ const accountWorkspaceTabs: Array<{ id: SettingsSectionId; label: string }> = [
 function SettingsAccountWorkspace({
   activeSection,
   canUseAccountTabs,
+  accountSwitchDisabled,
   currentAccountLabel,
   accountOptions,
   activeAccountId,
@@ -86,6 +87,7 @@ function SettingsAccountWorkspace({
 }: {
   activeSection: SettingsSectionId;
   canUseAccountTabs: boolean;
+  accountSwitchDisabled: boolean;
   currentAccountLabel: string;
   accountOptions: SettingsAccountOption[];
   activeAccountId: number | null;
@@ -108,6 +110,8 @@ function SettingsAccountWorkspace({
             <select
               aria-label="切换当前设置账号"
               value={activeAccountId ?? ''}
+              disabled={accountSwitchDisabled}
+              title={accountSwitchDisabled ? '请先保存或放弃当前账号的修改' : '切换当前设置账号'}
               onChange={(event) => onSelectAccountId?.(Number(event.target.value))}
             >
               {accountOptions.map((account) => (
@@ -191,7 +195,7 @@ export default function SettingsFrame({
   }, [isDirty]);
 
   const requestClose = () => {
-    if (isAccountEditingSection && isDirty) {
+    if (isDirty) {
       setShowDiscardConfirm(true);
       return;
     }
@@ -220,7 +224,7 @@ export default function SettingsFrame({
 
     window.addEventListener('keydown', handleKeyDown);
     return () => window.removeEventListener('keydown', handleKeyDown);
-  }, [isAccountEditingSection, isDirty, onClose, showDiscardConfirm]);
+  }, [isDirty, onClose, showDiscardConfirm]);
 
   return (
     <div
@@ -313,6 +317,7 @@ export default function SettingsFrame({
             <SettingsAccountWorkspace
               activeSection={activeSection}
               canUseAccountTabs={canSaveAndVerify}
+              accountSwitchDisabled={isDirty}
               currentAccountLabel={subtitle}
               accountOptions={accountOptions}
               activeAccountId={activeAccountId}

--- a/src/components/settings/SettingsFrame.tsx
+++ b/src/components/settings/SettingsFrame.tsx
@@ -1,7 +1,6 @@
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import type React from 'react';
 import {
-  ArrowLeft,
   FlaskConical,
   LoaderCircle,
   Save,
@@ -16,9 +15,7 @@ import {
 import {
   accountScopedSections,
   connectionSettingsSections,
-  generalScopedSections,
   getSettingsNavigationContext,
-  settingsNavigationItems,
   type SettingsSectionId,
 } from './settingsNavigation';
 import './settings-tokens.css';
@@ -30,9 +27,14 @@ import './settings-v3.css';
 
 export type { SettingsSectionId } from './settingsNavigation';
 
+type SettingsAccountOption = {
+  id: number;
+  label: string;
+  email: string;
+};
+
 type SettingsFrameProps = {
   title: string;
-  subtitle?: string;
   activeSection: SettingsSectionId;
   children: React.ReactNode;
   onNavigate: (section: SettingsSectionId) => void;
@@ -42,6 +44,9 @@ type SettingsFrameProps = {
   isDirty?: boolean;
   isBusy?: boolean;
   connectionSummary?: string;
+  accountOptions?: SettingsAccountOption[];
+  activeAccountId?: number | null;
+  onSelectAccountId?: (accountId: number) => void;
   onClose: () => void;
 };
 
@@ -55,6 +60,8 @@ const saveAndVerifySettingsSections = new Set<SettingsSectionId>([
 const compactSettingsSections = new Set<SettingsSectionId>([
   'appearance',
   'sending',
+  'notifications',
+  'about',
 ]);
 
 const accountWorkspaceTabs: Array<{ id: SettingsSectionId; label: string }> = [
@@ -66,56 +73,78 @@ const accountWorkspaceTabs: Array<{ id: SettingsSectionId; label: string }> = [
   { id: 'privacy', label: '隐私' },
 ];
 
-const generalWorkspaceTabs: Array<{ id: SettingsSectionId; label: string }> = [
-  { id: 'appearance', label: '外观' },
-  { id: 'sending', label: '发送' },
-];
-
-function SettingsContextTabs({
+function SettingsAccountWorkspace({
   activeSection,
   canUseAccountTabs,
+  accountOptions,
+  activeAccountId,
+  connectionSummary,
+  onSelectAccountId,
   onNavigate,
 }: {
   activeSection: SettingsSectionId;
   canUseAccountTabs: boolean;
+  accountOptions: SettingsAccountOption[];
+  activeAccountId: number | null;
+  connectionSummary?: string;
+  onSelectAccountId?: (accountId: number) => void;
   onNavigate: (section: SettingsSectionId) => void;
 }) {
-  const tabs = accountScopedSections.has(activeSection)
-    ? accountWorkspaceTabs
-    : generalScopedSections.has(activeSection)
-      ? generalWorkspaceTabs
-      : null;
-  if (!tabs) return null;
+  if (!accountScopedSections.has(activeSection)) return null;
 
-  const accountScope = accountScopedSections.has(activeSection);
+  const hasConnectionSummary = Boolean(connectionSummary)
+    && connectionSummary !== '尚未开始验证';
+
   return (
-    <nav
-      className="settings-context-tabs"
-      aria-label={accountScope ? '账号设置分类' : '通用设置分类'}
-    >
-      {tabs.map((tab) => {
-        const disabled = accountScope && tab.id !== 'accounts' && !canUseAccountTabs;
-        return (
-          <button
-            type="button"
-            className={tab.id === activeSection ? 'active' : ''}
-            aria-current={tab.id === activeSection ? 'page' : undefined}
-            disabled={disabled}
-            title={disabled ? '请先添加或选择邮箱账号' : undefined}
-            onClick={() => onNavigate(tab.id)}
-            key={tab.id}
+    <div className="settings-account-workspace">
+      <div className="settings-account-workspace-topline">
+        <label className="settings-account-picker">
+          <span>当前账号</span>
+          <select
+            aria-label="切换当前设置账号"
+            value={activeAccountId ?? ''}
+            disabled={accountOptions.length === 0 || !onSelectAccountId}
+            onChange={(event) => onSelectAccountId?.(Number(event.target.value))}
           >
-            {tab.label}
-          </button>
-        );
-      })}
-    </nav>
+            {accountOptions.length === 0 ? (
+              <option value="">尚未添加账号</option>
+            ) : accountOptions.map((account) => (
+              <option value={account.id} key={account.id}>
+                {account.label} · {account.email}
+              </option>
+            ))}
+          </select>
+        </label>
+        {hasConnectionSummary && (
+          <span className="settings-account-connection-state" title={connectionSummary}>
+            {connectionSummary}
+          </span>
+        )}
+      </div>
+      <nav className="settings-context-tabs" aria-label="账号设置分类">
+        {accountWorkspaceTabs.map((tab) => {
+          const disabled = tab.id !== 'accounts' && !canUseAccountTabs;
+          return (
+            <button
+              type="button"
+              className={tab.id === activeSection ? 'active' : ''}
+              aria-current={tab.id === activeSection ? 'page' : undefined}
+              disabled={disabled}
+              title={disabled ? '请先添加或选择邮箱账号' : undefined}
+              onClick={() => onNavigate(tab.id)}
+              key={tab.id}
+            >
+              {tab.label}
+            </button>
+          );
+        })}
+      </nav>
+    </div>
   );
 }
 
 export default function SettingsFrame({
   title,
-  subtitle = '',
   activeSection,
   children,
   onNavigate,
@@ -125,25 +154,19 @@ export default function SettingsFrame({
   isDirty = false,
   isBusy = false,
   connectionSummary,
+  accountOptions = [],
+  activeAccountId = null,
+  onSelectAccountId,
   onClose,
 }: SettingsFrameProps) {
   const {
     group: activeGroup,
     item: activeItem,
-    index: activeIndex,
   } = getSettingsNavigationContext(activeSection);
   const isAccountEditingSection = saveAndVerifySettingsSections.has(activeSection);
   const canActOnConnection = connectionSettingsSections.has(activeSection) && canSaveAndVerify;
-  const shouldShowConnectionSummary = isAccountEditingSection
-    && canSaveAndVerify
-    && Boolean(connectionSummary)
-    && connectionSummary !== '尚未开始验证';
-  const headerAction = isAccountEditingSection && canSaveAndVerify && isDirty
-    ? 'save'
-    : canActOnConnection
-      ? 'test'
-      : null;
-  const visibleSubtitle = accountScopedSections.has(activeSection) ? subtitle : '';
+  const showSaveAction = isAccountEditingSection && canSaveAndVerify;
+  const [showDiscardConfirm, setShowDiscardConfirm] = useState(false);
   const modalRef = useRef<HTMLElement | null>(null);
   const backdropRef = useRef<HTMLDivElement | null>(null);
   const closeButtonRef = useRef<HTMLButtonElement | null>(null);
@@ -155,40 +178,47 @@ export default function SettingsFrame({
   });
 
   useEffect(() => {
+    if (!isDirty) setShowDiscardConfirm(false);
+  }, [isDirty]);
+
+  const requestClose = () => {
+    if (isAccountEditingSection && isDirty) {
+      setShowDiscardConfirm(true);
+      return;
+    }
+    onClose();
+  };
+
+  useEffect(() => {
     function handleKeyDown(event: KeyboardEvent) {
-      if (event.defaultPrevented) return;
-      if (event.key === 'Escape') {
-        const settingsDialog = modalRef.current;
-        const startedInNestedDialog = settingsDialog !== null
-          && event.composedPath().some((target) => (
-            target instanceof HTMLElement
-            && target !== settingsDialog
-            && target.matches('[aria-modal="true"]')
-          ));
-        if (startedInNestedDialog) return;
-        event.preventDefault();
-        onClose();
+      if (event.defaultPrevented || event.key !== 'Escape') return;
+      const settingsDialog = modalRef.current;
+      const startedInNestedDialog = settingsDialog !== null
+        && event.composedPath().some((target) => (
+          target instanceof HTMLElement
+          && target !== settingsDialog
+          && target.matches('[aria-modal="true"]')
+        ));
+      if (startedInNestedDialog) return;
+
+      event.preventDefault();
+      if (showDiscardConfirm) {
+        setShowDiscardConfirm(false);
         return;
       }
-      if (!event.altKey) return;
-      const direction = event.key === 'ArrowLeft' ? -1 : event.key === 'ArrowRight' ? 1 : 0;
-      const target = direction === 0 ? null : settingsNavigationItems[activeIndex + direction];
-      if (target) {
-        event.preventDefault();
-        onNavigate(target.id);
-      }
+      requestClose();
     }
 
     window.addEventListener('keydown', handleKeyDown);
     return () => window.removeEventListener('keydown', handleKeyDown);
-  }, [activeIndex, onClose, onNavigate]);
+  }, [isAccountEditingSection, isDirty, onClose, showDiscardConfirm]);
 
   return (
     <div
       className="settings-backdrop"
       ref={backdropRef}
       onMouseDown={(event) => {
-        if (event.target === event.currentTarget) onClose();
+        if (event.target === event.currentTarget) requestClose();
       }}
     >
       <section
@@ -204,38 +234,33 @@ export default function SettingsFrame({
           <div className="settings-title">
             <span className="settings-title-copy">
               <strong>{title}</strong>
-              {visibleSubtitle && (
-                <small>
-                  {visibleSubtitle}
-                  {isAccountEditingSection && isDirty ? ' · 有未保存修改' : ''}
-                </small>
-              )}
             </span>
           </div>
           <div className="settings-header-actions">
-            {headerAction === 'save' && (
-              <button
-                type="button"
-                className="settings-header-button primary"
-                aria-label="保存账号设置"
-                title="保存当前账号设置"
-                disabled={isBusy}
-                onClick={onSave}
-              >
-                {isBusy ? <LoaderCircle className="settings-action-spinner" size={15} /> : <Save size={15} />}
-                <span>{isBusy ? '保存中' : '保存修改'}</span>
-              </button>
-            )}
-            {headerAction === 'test' && (
+            {canActOnConnection && (
               <button
                 type="button"
                 className="settings-header-button secondary"
                 aria-label="测试连接"
                 title="测试当前账号的 IMAP 与 SMTP 服务器连接"
+                disabled={isBusy}
                 onClick={onTestConnection}
               >
                 <FlaskConical size={15} />
                 <span>测试连接</span>
+              </button>
+            )}
+            {showSaveAction && (
+              <button
+                type="button"
+                className="settings-header-button primary"
+                aria-label="保存账号设置"
+                title={isDirty ? '保存当前账号设置' : '当前没有未保存修改'}
+                disabled={isBusy || !isDirty}
+                onClick={onSave}
+              >
+                {isBusy ? <LoaderCircle className="settings-action-spinner" size={15} /> : <Save size={15} />}
+                <span>{isBusy ? '保存中' : '保存修改'}</span>
               </button>
             )}
             <button
@@ -245,18 +270,26 @@ export default function SettingsFrame({
               aria-label="关闭设置"
               title="关闭设置"
               data-no-tooltip
-              onClick={onClose}
+              onClick={requestClose}
             >
-              <ArrowLeft className="settings-mobile-back-icon" size={18} aria-hidden="true" />
-              <X className="settings-desktop-close-icon" size={16} aria-hidden="true" />
+              <X size={16} aria-hidden="true" />
             </button>
           </div>
         </header>
-        {shouldShowConnectionSummary && (
-          <div className="settings-connection-summary" aria-live="polite">
-            {connectionSummary}
+
+        {showDiscardConfirm && (
+          <div className="settings-discard-confirm" role="alertdialog" aria-label="放弃未保存的修改">
+            <span>
+              <strong>放弃未保存的修改？</strong>
+              <small>当前账号的修改还没有保存。</small>
+            </span>
+            <div>
+              <button type="button" onClick={() => setShowDiscardConfirm(false)}>继续编辑</button>
+              <button type="button" className="danger" onClick={onClose}>放弃修改</button>
+            </div>
           </div>
         )}
+
         <div className="settings-body">
           <SettingsSidebar
             activeSection={activeSection}
@@ -268,9 +301,13 @@ export default function SettingsFrame({
               activeItem={activeItem}
               onNavigate={onNavigate}
             />
-            <SettingsContextTabs
+            <SettingsAccountWorkspace
               activeSection={activeSection}
               canUseAccountTabs={canSaveAndVerify}
+              accountOptions={accountOptions}
+              activeAccountId={activeAccountId}
+              connectionSummary={connectionSummary}
+              onSelectAccountId={onSelectAccountId}
               onNavigate={onNavigate}
             />
             <SettingsPageShell

--- a/src/components/settings/SettingsNavigationControls.tsx
+++ b/src/components/settings/SettingsNavigationControls.tsx
@@ -32,6 +32,18 @@ function focusSearchTarget(entry: SettingsSearchEntry) {
       ? document.querySelector<HTMLElement>(`[data-settings-section="${entry.target}"]`)
       : document.querySelector<HTMLElement>(`[data-settings-page="${entry.section}"]`);
     if (!target) return;
+
+    const disclosures = [
+      ...(target instanceof HTMLDetailsElement ? [target] : []),
+      ...Array.from(target.querySelectorAll<HTMLDetailsElement>('details')),
+    ];
+    let ancestor = target.parentElement;
+    while (ancestor) {
+      if (ancestor instanceof HTMLDetailsElement) disclosures.push(ancestor);
+      ancestor = ancestor.parentElement;
+    }
+    disclosures.forEach((details) => { details.open = true; });
+
     target.scrollIntoView({ block: 'center', behavior: 'smooth' });
     target.classList.add('settings-search-hit');
     window.setTimeout(() => target.classList.remove('settings-search-hit'), 1200);

--- a/src/components/settings/SettingsNavigationControls.tsx
+++ b/src/components/settings/SettingsNavigationControls.tsx
@@ -13,7 +13,10 @@ import {
 import {
   resolveSettingsNavigationSectionId,
   settingsNavigationGroups,
+  settingsNavigationItems,
+  settingsSearchEntries,
   type SettingsNavigationItem,
+  type SettingsSearchEntry,
   type SettingsSectionId,
 } from './settingsNavigation';
 
@@ -22,6 +25,18 @@ type SettingsNavigationProps = {
   activeItem: SettingsNavigationItem;
   onNavigate: (section: SettingsSectionId) => void;
 };
+
+function focusSearchTarget(entry: SettingsSearchEntry) {
+  window.setTimeout(() => {
+    const target = entry.target
+      ? document.querySelector<HTMLElement>(`[data-settings-section="${entry.target}"]`)
+      : document.querySelector<HTMLElement>(`[data-settings-page="${entry.section}"]`);
+    if (!target) return;
+    target.scrollIntoView({ block: 'center', behavior: 'smooth' });
+    target.classList.add('settings-search-hit');
+    window.setTimeout(() => target.classList.remove('settings-search-hit'), 1200);
+  }, 80);
+}
 
 export const SettingsSidebar = memo(function SettingsSidebar({
   activeSection,
@@ -34,32 +49,30 @@ export const SettingsSidebar = memo(function SettingsSidebar({
 
   useEffect(() => {
     function handleGlobalKeyDown(event: KeyboardEvent) {
-      if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === 'k') {
+      if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === 'f') {
         event.preventDefault();
         searchInputRef.current?.focus();
+        searchInputRef.current?.select();
       }
     }
     window.addEventListener('keydown', handleGlobalKeyDown);
     return () => window.removeEventListener('keydown', handleGlobalKeyDown);
   }, []);
 
-  const filteredGroups = useMemo(() => {
-    if (!normalizedQuery) return settingsNavigationGroups;
-    return settingsNavigationGroups
-      .map((group) => ({
-        ...group,
-        items: group.items.filter((item) => (
-          `${item.label} ${item.description} ${(item.keywords || []).join(' ')}`
-            .toLowerCase()
-            .includes(normalizedQuery)
-        )),
-      }))
-      .filter((group) => group.items.length > 0);
+  const searchResults = useMemo(() => {
+    if (!normalizedQuery) return [];
+    return settingsSearchEntries.filter((entry) => (
+      `${entry.label} ${entry.path} ${entry.keywords.join(' ')}`
+        .toLowerCase()
+        .includes(normalizedQuery)
+    )).slice(0, 10);
   }, [normalizedQuery]);
 
-  const totalMatchCount = useMemo(() => {
-    return filteredGroups.reduce((acc, group) => acc + group.items.length, 0);
-  }, [filteredGroups]);
+  const navigateToSearchResult = (entry: SettingsSearchEntry) => {
+    onNavigate(entry.section);
+    setQuery('');
+    focusSearchTarget(entry);
+  };
 
   return (
     <nav className="settings-nav" aria-label="设置分类">
@@ -68,9 +81,9 @@ export const SettingsSidebar = memo(function SettingsSidebar({
         <input
           ref={searchInputRef}
           type="search"
-          aria-label="搜索设置页面 (Cmd+K)"
+          aria-label="搜索设置"
           value={query}
-          placeholder="搜索设置 (⌘K)"
+          placeholder="搜索设置"
           onInput={(event) => setQuery(event.currentTarget.value)}
         />
         {query ? (
@@ -83,19 +96,44 @@ export const SettingsSidebar = memo(function SettingsSidebar({
             <X size={13} />
           </button>
         ) : (
-          <kbd className="settings-search-shortcut">⌘K</kbd>
+          <kbd className="settings-search-shortcut">⌘F</kbd>
         )}
       </div>
-      {query && (
-        <div className="settings-nav-match-count">
-          找到 {totalMatchCount} 个相关设置
-        </div>
-      )}
+
       <div className="settings-nav-scroll">
-        {filteredGroups.map((group) => (
-          <div className="settings-nav-section" key={group.label}>
-            <span className="settings-nav-group">{group.label}</span>
-            {group.items.map((item) => {
+        {normalizedQuery ? (
+          <div className="settings-search-results" aria-label="设置搜索结果">
+            <span className="settings-nav-match-count">
+              {searchResults.length > 0 ? `${searchResults.length} 个匹配` : '没有匹配'}
+            </span>
+            {searchResults.map((entry) => (
+              <button
+                type="button"
+                className="settings-search-result"
+                key={`${entry.section}-${entry.label}`}
+                onClick={() => navigateToSearchResult(entry)}
+              >
+                <strong>{entry.label}</strong>
+                <small>{entry.path}</small>
+              </button>
+            ))}
+            {searchResults.length === 0 && (
+              <div className="settings-nav-empty">
+                <strong>没有找到这个设置</strong>
+                <span>试试“附件”“撤销发送”或“免打扰”</span>
+                <button
+                  type="button"
+                  className="st-btn st-btn-secondary st-btn-sm"
+                  onClick={() => setQuery('')}
+                >
+                  清除搜索
+                </button>
+              </div>
+            )}
+          </div>
+        ) : (
+          <div className="settings-nav-list">
+            {settingsNavigationItems.map((item) => {
               const Icon = item.icon;
               const active = resolvedActiveSection === item.id;
               return (
@@ -116,19 +154,6 @@ export const SettingsSidebar = memo(function SettingsSidebar({
                 </button>
               );
             })}
-          </div>
-        ))}
-        {filteredGroups.length === 0 && (
-          <div className="settings-nav-empty">
-            <strong>没有匹配的设置</strong>
-            <span>换一个关键词试试</span>
-            <button
-              type="button"
-              className="st-btn st-btn-secondary st-btn-sm"
-              onClick={() => setQuery('')}
-            >
-              清除搜索
-            </button>
           </div>
         )}
       </div>

--- a/src/components/settings/SettingsPageShell.tsx
+++ b/src/components/settings/SettingsPageShell.tsx
@@ -5,7 +5,10 @@ import type {
   SettingsNavigationItem,
   SettingsSectionId,
 } from './settingsNavigation';
-import { getSettingsSectionPresentation } from './settingsNavigation';
+import {
+  accountScopedSections,
+  getSettingsSectionPresentation,
+} from './settingsNavigation';
 
 type SettingsPageShellProps = {
   activeSection: SettingsSectionId;
@@ -22,6 +25,7 @@ export default function SettingsPageShell({
 }: SettingsPageShellProps) {
   const pageRef = useRef<HTMLElement | null>(null);
   const presentation = getSettingsSectionPresentation(activeSection) ?? item;
+  const accountWorkspace = accountScopedSections.has(activeSection);
 
   useEffect(() => {
     if (pageRef.current) {
@@ -36,15 +40,18 @@ export default function SettingsPageShell({
       className="settings-page"
       data-settings-page={activeSection}
       data-settings-group={group.label}
-      aria-labelledby={`settings-page-${activeSection}`}
-      aria-describedby={`settings-page-description-${activeSection}`}
+      aria-label={accountWorkspace ? presentation.label : undefined}
+      aria-labelledby={accountWorkspace ? undefined : `settings-page-${activeSection}`}
+      aria-describedby={accountWorkspace ? undefined : `settings-page-description-${activeSection}`}
     >
-      <header className="settings-page-header">
-        <div className="settings-page-heading">
-          <h2 id={`settings-page-${activeSection}`}>{presentation.label}</h2>
-          <p id={`settings-page-description-${activeSection}`}>{presentation.description}</p>
-        </div>
-      </header>
+      {!accountWorkspace && (
+        <header className="settings-page-header">
+          <div className="settings-page-heading">
+            <h2 id={`settings-page-${activeSection}`}>{presentation.label}</h2>
+            <p id={`settings-page-description-${activeSection}`}>{presentation.description}</p>
+          </div>
+        </header>
+      )}
       <div className="settings-page-content">{children}</div>
     </section>
   );

--- a/src/components/settings/SyncOperationsSettings.tsx
+++ b/src/components/settings/SyncOperationsSettings.tsx
@@ -31,7 +31,6 @@ import {
   SettingsEmptyState,
   SettingsSection,
 } from './shared';
-
 import { devMode } from './settingsNavigation';
 
 type SyncOperationsSettingsProps = {
@@ -107,7 +106,7 @@ export default function SyncOperationsSettings({
       {devMode && (
         <SettingsSection
           title="IMAP 文件夹发现"
-          description="读取远端邮箱文件夹 structure 并映射本地角色"
+          description="读取远端目录并检查映射状态。"
           actions={
             <SettingsButton icon={<Search size={14} />} onClick={onDiscoverImapFolders}>
               发现文件夹
@@ -115,7 +114,7 @@ export default function SyncOperationsSettings({
           }
         >
           {!imapProbe ? (
-            <SettingsEmptyState>保存本地凭据后，可真实登录 IMAP 并读取远端文件夹列表。</SettingsEmptyState>
+            <SettingsEmptyState>保存本地凭据后，可登录 IMAP 并读取远端文件夹。</SettingsEmptyState>
           ) : (
             <>
               <div className={imapProbe.status === 'ok' ? 'st-data-row ok' : 'st-data-row warn'}>
@@ -139,8 +138,8 @@ export default function SyncOperationsSettings({
       )}
 
       <SettingsSection
-        title="同步设置"
-        description={devMode ? '检查调度批次和文件夹状态' : '同步状态与手动刷新邮件头'}
+        title="同步"
+        description="查看文件夹状态并手动刷新邮件。"
         actions={
           <div className="st-actions">
             {devMode && <SettingsButton onClick={onRunSyncDryRun}>演练</SettingsButton>}
@@ -155,13 +154,13 @@ export default function SyncOperationsSettings({
               </SettingsButton>
             )}
             <SettingsButton variant="primary" icon={<RefreshCw size={14} />} onClick={() => onEnqueueBackgroundTask('sync', 'manual')}>
-              同步邮件头
+              同步邮件
             </SettingsButton>
           </div>
         }
         dataSection="sync"
       >
-        {syncSchedulePlan && (
+        {devMode && syncSchedulePlan && (
           <div className="sync-schedule-card">
             <div>
               <span>同步调度与限流</span>
@@ -253,44 +252,46 @@ export default function SyncOperationsSettings({
         )}
       </SettingsSection>
 
-      <SettingsSection
-        title="发件箱队列"
-        description="查看排队、定时发送、重试和撤回状态"
-        actions={devMode ? (
-          <div className="st-actions">
-            <SettingsButton onClick={() => onEnqueueBackgroundTask('outbox-dry-run', 'manual')}>
-              发送演练
-            </SettingsButton>
-            <SettingsButton variant="primary" icon={<Send size={14} />} onClick={() => onEnqueueBackgroundTask('outbox-smtp', 'manual')}>
-              真实发送
-            </SettingsButton>
-          </div>
-        ) : undefined}
-      >
-        {outbox.length === 0 ? (
-          <SettingsEmptyState>发件箱当前为空。</SettingsEmptyState>
-        ) : (
-          <div className="st-list">
-            {outbox.map((item) => (
-              <div className="st-data-row" key={item.id}>
-                <span>{outboxStatusLabel(item.status)}</span>
-                <em>{item.recipients}</em>
-                <small>{item.attempts} 次</small>
-                <p>
-                  {item.subject || '(无主题)'}
-                  {outboxTimingLabel(item) ? ` · ${outboxTimingLabel(item)}` : ''}
-                  {item.last_error ? ` · ${item.last_error}` : ''}
-                </p>
-                {canCancelOutboxItem(item.status) && (
-                  <SettingsButton size="sm" variant="danger-secondary" onClick={() => onCancelOutboxItem(item)}>
-                    撤回
-                  </SettingsButton>
-                )}
-              </div>
-            ))}
-          </div>
-        )}
-      </SettingsSection>
+      {devMode && (
+        <SettingsSection
+          title="发件箱队列"
+          description="开发模式下检查排队、重试与撤回状态。"
+          actions={(
+            <div className="st-actions">
+              <SettingsButton onClick={() => onEnqueueBackgroundTask('outbox-dry-run', 'manual')}>
+                发送演练
+              </SettingsButton>
+              <SettingsButton variant="primary" icon={<Send size={14} />} onClick={() => onEnqueueBackgroundTask('outbox-smtp', 'manual')}>
+                真实发送
+              </SettingsButton>
+            </div>
+          )}
+        >
+          {outbox.length === 0 ? (
+            <SettingsEmptyState>发件箱当前为空。</SettingsEmptyState>
+          ) : (
+            <div className="st-list">
+              {outbox.map((item) => (
+                <div className="st-data-row" key={item.id}>
+                  <span>{outboxStatusLabel(item.status)}</span>
+                  <em>{item.recipients}</em>
+                  <small>{item.attempts} 次</small>
+                  <p>
+                    {item.subject || '(无主题)'}
+                    {outboxTimingLabel(item) ? ` · ${outboxTimingLabel(item)}` : ''}
+                    {item.last_error ? ` · ${item.last_error}` : ''}
+                  </p>
+                  {canCancelOutboxItem(item.status) && (
+                    <SettingsButton size="sm" variant="danger-secondary" onClick={() => onCancelOutboxItem(item)}>
+                      撤回
+                    </SettingsButton>
+                  )}
+                </div>
+              ))}
+            </div>
+          )}
+        </SettingsSection>
+      )}
     </div>
   );
 }

--- a/src/components/settings/pages/AccountSettingsPage.tsx
+++ b/src/components/settings/pages/AccountSettingsPage.tsx
@@ -1,5 +1,4 @@
 import { useEffect, useState } from 'react';
-import { BadgeCheck, KeyRound, RefreshCw, Server, ShieldCheck } from 'lucide-react';
 import type { Account, AccountCreateInput, IncomingProtocol } from '../../../app/types';
 import { incomingHostForProtocol, providerPresetForEmail, providerPresets } from '../../../providerCatalog';
 import type { AccountProviderPreset } from '../../../providerCatalog';
@@ -11,7 +10,6 @@ import { syncModeOptions } from '../accounts/accountSettingsShared';
 import { accountFormForEmail, accountFormForIncomingProtocol } from '../accounts/accountSetupForm';
 import { CustomSelect } from '../accounts/CustomSelect';
 import {
-  SettingsButton,
   SettingsField,
   SettingsSection,
   SettingsSwitch,
@@ -37,18 +35,6 @@ type AccountSettingsPageProps = {
   onNavigate: (section: SettingsSectionId) => void;
 };
 
-const accountQuickLinks: Array<{
-  id: SettingsSectionId;
-  label: string;
-  icon: typeof Server;
-}> = [
-  { id: 'providers', label: '服务器', icon: Server },
-  { id: 'auth', label: '登录与安全', icon: KeyRound },
-  { id: 'identities', label: '身份与签名', icon: BadgeCheck },
-  { id: 'sync', label: '同步', icon: RefreshCw },
-  { id: 'privacy', label: '隐私', icon: ShieldCheck },
-];
-
 export default function AccountSettingsPage({
   accounts,
   accountForm,
@@ -60,7 +46,6 @@ export default function AccountSettingsPage({
   onCreateNewAccount,
   onRemoveAccount,
   onSaveAccountSettings,
-  onNavigate,
 }: AccountSettingsPageProps) {
   const [addDialogOpen, setAddDialogOpen] = useState(false);
   const [newAccountSecret, setNewAccountSecret] = useState('');
@@ -175,8 +160,8 @@ export default function AccountSettingsPage({
 
       {accountForm && (
         <SettingsSection
-          title={accountForm.display_name || accountForm.email}
-          description={`${accountForm.email} · ${accountForm.provider}`}
+          title="账号偏好"
+          description={accountForm.email}
           className="settings-account-overview"
           dataSection="account-overview"
         >
@@ -191,7 +176,7 @@ export default function AccountSettingsPage({
                 placeholder="默认使用邮箱地址"
               />
             </SettingsField>
-            <SettingsField label="获取新邮件" hint="控制此账号的后台检查频率">
+            <SettingsField label="获取新邮件" hint="控制后台检查频率">
               <CustomSelect
                 dense
                 value={accountForm.sync_mode === 'push' ? '5min' : accountForm.sync_mode}
@@ -203,7 +188,7 @@ export default function AccountSettingsPage({
 
           <SettingsSwitch
             label="跨邮箱发送风险提示"
-            description="回复其他账号的邮件或快捷写信账号不一致时，在发送前提醒。"
+            description="发件账号与当前邮件不一致时，在发送前提醒。"
             checked={accountForm.cross_account_risk_warning !== false}
             onChange={(checked) => onAccountFormChange({
               ...accountForm,
@@ -212,35 +197,18 @@ export default function AccountSettingsPage({
           />
           <SettingsSwitch
             label="自动下载新邮件附件"
-            description="同步新邮件时自动把附件保存到本地下载位置。"
+            description="收到新邮件时自动将附件保存到本地下载位置。"
             checked={accountForm.auto_download_attachments}
             onChange={(checked) => onAccountFormChange({
               ...accountForm,
               auto_download_attachments: checked,
             })}
           />
-
-          <div className="settings-account-quick-links" aria-label="账号详细设置">
-            {accountQuickLinks.map((item) => {
-              const Icon = item.icon;
-              return (
-                <SettingsButton
-                  size="sm"
-                  variant="ghost"
-                  icon={<Icon size={13} />}
-                  onClick={() => onNavigate(item.id)}
-                  key={item.id}
-                >
-                  {item.label}
-                </SettingsButton>
-              );
-            })}
-          </div>
         </SettingsSection>
       )}
 
       {!accountForm && accounts.length === 0 && (
-        <div className="settings-inline-status">添加第一个邮箱账号后，即可统一管理服务器、登录、身份、同步和隐私。</div>
+        <div className="settings-inline-status">添加第一个邮箱账号后，即可配置服务器、登录、身份、同步和隐私。</div>
       )}
 
       {addDialogOpen && (

--- a/src/components/settings/pages/NotificationSettingsPage.test.tsx
+++ b/src/components/settings/pages/NotificationSettingsPage.test.tsx
@@ -35,25 +35,26 @@ describe('NotificationSettingsPage', () => {
     cleanup();
   });
 
-  it('shows the current policy scope in the header status', () => {
+  it('renders compact primary notification controls', () => {
     renderPage(makePolicy({ vipOnly: true, quietHoursEnabled: true }), []);
-    expect(screen.getByTitle('当前生效的通知范围').textContent).toContain('仅 VIP');
-    expect(screen.getByTitle('当前生效的通知范围').textContent).toContain('免打扰');
+    expect(screen.getByText('通知')).not.toBeNull();
+    expect(screen.getByText('只保留真正需要打断你的提醒。')).not.toBeNull();
+    expect(screen.getByRole('checkbox', { name: /^只提醒 VIP/ })).not.toBeNull();
+    expect(screen.getByRole('checkbox', { name: /^免打扰/ })).not.toBeNull();
   });
 
-  it('dimms and disables quiet hours time inputs while the toggle is off', () => {
+  it('hides quiet hours time inputs while the toggle is off', () => {
     const { container } = renderPage(makePolicy({ quietHoursEnabled: false }), []);
     const times = container.querySelector('.notification-quiet-times');
-    expect(times?.className).toContain('is-dimmed');
-    const start = screen.getByLabelText('免打扰开始') as HTMLInputElement;
-    expect(start.disabled).toBe(true);
+    expect(times).toBeNull();
+    expect(screen.queryByLabelText('开始')).toBeNull();
   });
 
   it('enables quiet hours time inputs after the toggle is on', () => {
     const { container } = renderPage(makePolicy({ quietHoursEnabled: true }), []);
     const times = container.querySelector('.notification-quiet-times');
     expect(times?.className).not.toContain('is-dimmed');
-    const start = screen.getByLabelText('免打扰开始') as HTMLInputElement;
+    const start = screen.getByLabelText('开始') as HTMLInputElement;
     expect(start.disabled).toBe(false);
   });
 
@@ -64,10 +65,10 @@ describe('NotificationSettingsPage', () => {
 
     const workButtons = screen.getAllByRole('group', { name: 'work@example.com 提醒模式' })[0];
     const workLabels = Array.from(workButtons.querySelectorAll('button')).map((button) => button.textContent);
-    expect(workLabels).toEqual(['正常通知', '优先提醒', '不通知']);
+    expect(workLabels).toEqual(['正常', '优先', '静音']);
 
     const priorityButton = Array.from(workButtons.querySelectorAll('button'))
-      .find((button) => button.textContent === '优先提醒');
+      .find((button) => button.textContent === '优先');
     expect(priorityButton?.getAttribute('aria-pressed')).toBe('true');
   });
 
@@ -82,7 +83,8 @@ describe('NotificationSettingsPage', () => {
       mutedAccounts: 'archive@example.com',
     });
     renderPage(policy, accounts);
-    expect(screen.getByText('1 个优先 · 1 个静音')).not.toBeNull();
+    const accountRules = screen.getByText('账号通知优先级').closest('details');
+    expect(accountRules?.querySelector('em')?.textContent).toBe('1 优先 · 1 静音');
   });
 
   it('renders VIP senders as chips with an add form instead of a textarea', () => {
@@ -140,11 +142,11 @@ describe('NotificationSettingsPage', () => {
     expect(screen.queryByRole('textbox', { name: '重点账号' })).toBeNull();
   });
 
-  it('explains the rule evaluation order', () => {
+  it('groups account and sender exceptions behind disclosures', () => {
     renderPage(makePolicy(), []);
-    const order = screen.getByLabelText('规则优先级说明');
-    expect(order.textContent).toContain('静音账号');
-    expect(order.textContent).toContain('免打扰时段');
-    expect(order.textContent).toContain('正常通知');
+    expect(screen.getByText('账号通知优先级')).not.toBeNull();
+    expect(screen.getByText('为不同邮箱设置正常、优先或静音。')).not.toBeNull();
+    expect(screen.getByText('VIP 发件人')).not.toBeNull();
+    expect(screen.getByText('这些发件人的邮件可以穿透免打扰。')).not.toBeNull();
   });
 });

--- a/src/components/settings/pages/NotificationSettingsPage.tsx
+++ b/src/components/settings/pages/NotificationSettingsPage.tsx
@@ -11,7 +11,6 @@ import {
 } from '../../../app/appConfig';
 import type { NotificationPolicy } from '../../../mailUtils';
 import {
-  SettingsBadge,
   SettingsButton,
   SettingsEmptyState,
   SettingsNotice,
@@ -30,18 +29,10 @@ const accountModeOptions: {
   label: string;
   description: string;
 }[] = [
-  { mode: 'normal', label: '正常通知', description: '按全局策略提醒' },
-  { mode: 'priority', label: '优先提醒', description: '免打扰时段内仍提醒' },
-  { mode: 'muted', label: '不通知', description: '此账号邮件不弹系统提醒' },
+  { mode: 'normal', label: '正常', description: '按全局策略提醒' },
+  { mode: 'priority', label: '优先', description: '免打扰时段内仍提醒' },
+  { mode: 'muted', label: '静音', description: '此账号邮件不弹系统提醒' },
 ];
-
-function policyStatusLabel(policy: NotificationPolicy): string {
-  const parts: string[] = [];
-  if (policy.vipOnly) parts.push('仅 VIP');
-  if (policy.quietHoursEnabled) parts.push(`免打扰 ${policy.quietStart}–${policy.quietEnd}`);
-  if (!policy.vipOnly && !policy.quietHoursEnabled) parts.push('全部新邮件');
-  return parts.join(' · ');
-}
 
 export default function NotificationSettingsPage({
   accounts,
@@ -57,8 +48,8 @@ export default function NotificationSettingsPage({
   const mutedCount = accounts.filter((item) => (
     getAccountNotificationMode(notificationPolicy, item.email) === 'muted'
   )).length;
-
   const vipEntries = vipSenderEntries(notificationPolicy.vipSenders);
+  const quietHoursOn = notificationPolicy.quietHoursEnabled;
 
   const addVipEntry = () => {
     const draft = vipDraft.trim();
@@ -82,191 +73,171 @@ export default function NotificationSettingsPage({
     });
   };
 
-  const quietHoursOn = notificationPolicy.quietHoursEnabled;
-
   return (
-    <SettingsSection
-      title="通知策略"
-      description="控制哪些邮件会通知你，以及什么时候不该被打扰"
-      badge={
-        <SettingsBadge tone="info" title="当前生效的通知范围">
-          {policyStatusLabel(notificationPolicy)}
-        </SettingsBadge>
-      }
-      dataSection="notifications"
-    >
-      <SettingsNotice tone="info" title="邮件到达时">
-        <p>VIP 发件人与重点账号优先提醒；免打扰时段内普通邮件静默，VIP 与重点账号仍然提醒。</p>
-      </SettingsNotice>
-
-      <div className="st-subsection">
+    <>
+      <SettingsSection
+        title="通知"
+        description="只保留真正需要打断你的提醒。"
+        dataSection="notifications"
+      >
         <SettingsSwitch
           label="只提醒 VIP"
-          description="忽略不在 VIP 发件人列表中的邮件，其余邮件全部静默。"
+          description="开启后，非 VIP 发件人的新邮件保持静默。"
           checked={notificationPolicy.vipOnly}
           onChange={(checked) => onNotificationPolicyChange({
             ...notificationPolicy,
             vipOnly: checked,
           })}
         />
-        <SettingsNotice tone="info">
-          <p>
-            <strong>VIP 发件人</strong> · {vipEntries.length > 0 ? `${vipEntries.length} 个` : '尚未设置'}
-          </p>
-        </SettingsNotice>
-      </div>
+        {notificationPolicy.vipOnly && vipEntries.length === 0 && (
+          <SettingsNotice tone="warning" title="还没有 VIP 发件人">
+            <p>当前开启后将不会收到普通新邮件提醒。请在下方“VIP 发件人”中至少添加一项。</p>
+          </SettingsNotice>
+        )}
 
-      <div className="st-subsection">
         <SettingsSwitch
-          label="免打扰时段"
-          description="开启后，仅 VIP 发件人与重点账号的邮件会在该时段内提醒。"
+          label="免打扰"
+          description="该时段内仅 VIP 发件人与优先账号可以提醒。"
           checked={quietHoursOn}
           onChange={(checked) => onNotificationPolicyChange({
             ...notificationPolicy,
             quietHoursEnabled: checked,
           })}
         />
-        <div className={`st-field-grid notification-quiet-times${quietHoursOn ? '' : ' is-dimmed'}`} aria-hidden={!quietHoursOn}>
-          <label className="st-field">
-            <span className="st-field-label">免打扰开始</span>
-            <input
-              type="time"
-              disabled={!quietHoursOn}
-              value={notificationPolicy.quietStart}
-              onChange={(event) => onNotificationPolicyChange({
-                ...notificationPolicy,
-                quietStart: event.target.value,
-              })}
-            />
-          </label>
-          <label className="st-field">
-            <span className="st-field-label">免打扰结束</span>
-            <input
-              type="time"
-              disabled={!quietHoursOn}
-              value={notificationPolicy.quietEnd}
-              onChange={(event) => onNotificationPolicyChange({
-                ...notificationPolicy,
-                quietEnd: event.target.value,
-              })}
-            />
-          </label>
-        </div>
-        {!quietHoursOn && (
-          <p className="st-field-hint">开启免打扰后，可在此设定开始与结束时间。</p>
-        )}
-      </div>
-
-      <div className="st-subsection">
-        <header className="st-subsection-header">
-          <span>
-            <strong>账号通知优先级</strong>
-            <small>为每个账号单独选择提醒方式；优先提醒账号会穿透免打扰时段。</small>
-          </span>
-          <SettingsBadge>{priorityCount} 个优先 · {mutedCount} 个静音</SettingsBadge>
-        </header>
-        <div className="notification-account-grid" aria-label="账号提醒模式">
-          {accounts.map((item) => {
-            const mode = getAccountNotificationMode(notificationPolicy, item.email);
-            return (
-              <div key={item.id} data-notification-account={item.email}>
-                <span>
-                  <strong>{item.display_name || item.email}</strong>
-                  <small>{item.email}</small>
-                </span>
-                <div className="notification-account-mode" role="group" aria-label={`${item.email} 提醒模式`}>
-                  {accountModeOptions.map((option) => {
-                    const active = mode === option.mode;
-                    return (
-                      <button
-                        type="button"
-                        className={active ? 'active' : ''}
-                        key={option.mode}
-                        data-mode={option.mode}
-                        aria-pressed={active}
-                        title={option.description}
-                        onClick={() => onNotificationPolicyChange(
-                          setAccountNotificationMode(notificationPolicy, item.email, option.mode),
-                        )}
-                      >
-                        {option.label}
-                      </button>
-                    );
-                  })}
-                </div>
-              </div>
-            );
-          })}
-          {accounts.length === 0 && (
-            <SettingsEmptyState>还没有可配置的邮箱账号。</SettingsEmptyState>
-          )}
-        </div>
-      </div>
-
-      <div className="st-subsection">
-        <header className="st-subsection-header">
-          <span>
-            <strong>发件人规则</strong>
-            <small>VIP 发件人的邮件始终提醒，且优先于普通邮件展示。</small>
-          </span>
-        </header>
-        <div className="vip-sender-editor">
-          <div className="vip-sender-input-row">
-            <input
-              type="text"
-              value={vipDraft}
-              placeholder="ada@example.com 或 @customer.com"
-              aria-label="添加 VIP 发件人"
-              aria-invalid={vipDraftError}
-              onChange={(event) => {
-                setVipDraft(event.target.value);
-                setVipDraftError(false);
-              }}
-              onKeyDown={(event) => {
-                if (event.key === 'Enter') {
-                  event.preventDefault();
-                  addVipEntry();
-                }
-              }}
-            />
-            <SettingsButton onClick={addVipEntry}>添加</SettingsButton>
+        {quietHoursOn && (
+          <div className="st-field-grid notification-quiet-times">
+            <label className="st-field">
+              <span className="st-field-label">开始</span>
+              <input
+                type="time"
+                value={notificationPolicy.quietStart}
+                onChange={(event) => onNotificationPolicyChange({
+                  ...notificationPolicy,
+                  quietStart: event.target.value,
+                })}
+              />
+            </label>
+            <label className="st-field">
+              <span className="st-field-label">结束</span>
+              <input
+                type="time"
+                value={notificationPolicy.quietEnd}
+                onChange={(event) => onNotificationPolicyChange({
+                  ...notificationPolicy,
+                  quietEnd: event.target.value,
+                })}
+              />
+            </label>
           </div>
-          {vipDraftError && (
-            <p className="st-field-error">请输入邮箱地址（如 ada@example.com）或域名（如 @customer.com）。</p>
-          )}
-          {vipEntries.length === 0 ? (
-            <SettingsEmptyState>
-              还没有 VIP 发件人。添加后，他们的邮件会优先提醒。
-            </SettingsEmptyState>
-          ) : (
-            <ul className="vip-sender-chips" aria-label="VIP 发件人列表">
-              {vipEntries.map((entry) => (
-                <li key={entry} className="vip-sender-chip">
-                  <span>{entry}</span>
-                  <button
-                    type="button"
-                    aria-label={`移除 ${entry}`}
-                    onClick={() => removeVipEntry(entry)}
-                  >
-                    ×
-                  </button>
-                </li>
-              ))}
-            </ul>
-          )}
-        </div>
-      </div>
+        )}
+      </SettingsSection>
 
-      <div className="notification-rule-order" aria-label="规则优先级说明">
-        <strong>规则判断顺序</strong>
-        <ol>
-          <li><span>静音账号</span>最先拦截，不弹系统提醒</li>
-          <li><span>只提醒 VIP</span>开启后，仅 VIP 发件人的邮件会提醒</li>
-          <li><span>免打扰时段</span>内暂停通知，VIP 发件人与重点账号仍会提醒</li>
-          <li><span>VIP 发件人 · 重点账号</span>优先提醒</li>
-          <li>其余邮件按<span>正常通知</span>处理</li>
-        </ol>
-      </div>
-    </SettingsSection>
+      <SettingsSection
+        title="优先与例外"
+        description="只有需要精细控制时才展开。"
+        dataSection="notification-exceptions"
+      >
+        <details className="settings-disclosure" data-settings-section="notification-account-rules">
+          <summary>
+            <span>
+              <strong>账号通知优先级</strong>
+              <small>为不同邮箱设置正常、优先或静音。</small>
+            </span>
+            <em>{priorityCount} 优先 · {mutedCount} 静音</em>
+          </summary>
+          <div className="settings-disclosure-body">
+            <div className="notification-account-grid" aria-label="账号提醒模式">
+              {accounts.map((item) => {
+                const mode = getAccountNotificationMode(notificationPolicy, item.email);
+                return (
+                  <div key={item.id} data-notification-account={item.email}>
+                    <span>
+                      <strong>{item.display_name || item.email}</strong>
+                      <small>{item.email}</small>
+                    </span>
+                    <div className="notification-account-mode" role="group" aria-label={`${item.email} 提醒模式`}>
+                      {accountModeOptions.map((option) => {
+                        const active = mode === option.mode;
+                        return (
+                          <button
+                            type="button"
+                            className={active ? 'active' : ''}
+                            key={option.mode}
+                            data-mode={option.mode}
+                            aria-pressed={active}
+                            title={option.description}
+                            onClick={() => onNotificationPolicyChange(
+                              setAccountNotificationMode(notificationPolicy, item.email, option.mode),
+                            )}
+                          >
+                            {option.label}
+                          </button>
+                        );
+                      })}
+                    </div>
+                  </div>
+                );
+              })}
+              {accounts.length === 0 && (
+                <SettingsEmptyState>还没有可配置的邮箱账号。</SettingsEmptyState>
+              )}
+            </div>
+          </div>
+        </details>
+
+        <details className="settings-disclosure" data-settings-section="notification-vip-rules">
+          <summary>
+            <span>
+              <strong>VIP 发件人</strong>
+              <small>这些发件人的邮件可以穿透免打扰。</small>
+            </span>
+            <em>{vipEntries.length} 个</em>
+          </summary>
+          <div className="settings-disclosure-body vip-sender-editor">
+            <div className="vip-sender-input-row">
+              <input
+                type="text"
+                value={vipDraft}
+                placeholder="ada@example.com 或 @customer.com"
+                aria-label="添加 VIP 发件人"
+                aria-invalid={vipDraftError}
+                onChange={(event) => {
+                  setVipDraft(event.target.value);
+                  setVipDraftError(false);
+                }}
+                onKeyDown={(event) => {
+                  if (event.key === 'Enter') {
+                    event.preventDefault();
+                    addVipEntry();
+                  }
+                }}
+              />
+              <SettingsButton onClick={addVipEntry}>添加</SettingsButton>
+            </div>
+            {vipDraftError && (
+              <p className="st-field-error">请输入邮箱地址或 @domain.com 形式的域名。</p>
+            )}
+            {vipEntries.length === 0 ? (
+              <SettingsEmptyState>还没有 VIP 发件人。</SettingsEmptyState>
+            ) : (
+              <ul className="vip-sender-chips" aria-label="VIP 发件人列表">
+                {vipEntries.map((entry) => (
+                  <li key={entry} className="vip-sender-chip">
+                    <span>{entry}</span>
+                    <button
+                      type="button"
+                      aria-label={`移除 ${entry}`}
+                      onClick={() => removeVipEntry(entry)}
+                    >
+                      ×
+                    </button>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>
+        </details>
+      </SettingsSection>
+    </>
   );
 }

--- a/src/components/settings/pages/PrivacySettingsPage.test.tsx
+++ b/src/components/settings/pages/PrivacySettingsPage.test.tsx
@@ -46,13 +46,13 @@ describe('PrivacySettingsPage', () => {
     renderPage(makeAccount({ remote_images_allowed: false }), []);
     const toggles = screen.getAllByRole('checkbox');
     expect(toggles.length).toBe(4);
-    expect(screen.getByText('默认阻止远程图片，减少追踪像素；可信发件人或域名可单独放行。')).not.toBeNull();
+    expect(screen.getByText('默认阻止远程图片与追踪像素；可信发件人或域名可单独放行。')).not.toBeNull();
     expect((toggles[0] as HTMLInputElement).checked).toBe(false);
   });
 
   it('explains the risk when remote images are allowed', () => {
     renderPage(makeAccount({ remote_images_allowed: true }), []);
-    expect(screen.getByText(/可能暴露你的打开行为与网络位置/)).not.toBeNull();
+    expect(screen.getByText(/可能暴露打开行为与网络位置/)).not.toBeNull();
     expect((screen.getAllByRole('checkbox')[0] as HTMLInputElement).checked).toBe(true);
   });
 
@@ -60,7 +60,7 @@ describe('PrivacySettingsPage', () => {
     renderPage(makeAccount(), []);
     expect(screen.getByText('拦截外部邮箱邮件')).not.toBeNull();
     expect(screen.getByText('隐藏邮件中的链接')).not.toBeNull();
-    expect(screen.getByText('提示来自其他邮箱 / 外部发件人的邮件')).not.toBeNull();
+    expect(screen.getByText('提示外部发件人')).not.toBeNull();
   });
 
   it('shows an explicit empty state for the trust list', () => {
@@ -68,25 +68,11 @@ describe('PrivacySettingsPage', () => {
     expect(screen.getByText('暂无信任项。你可以在邮件阅读页按发件人或域名允许图片。')).not.toBeNull();
   });
 
-  it('offers an account selector only when multiple accounts exist', () => {
-    renderPage(makeAccount(), []);
-    expect(screen.queryByLabelText('配置账号')).toBeNull();
+  it('does not duplicate the account selector inside the privacy page', () => {
     const second = makeAccount({ id: 2, email: 'home@example.com' });
     const first = makeAccount();
-    const select = vi.fn();
-    render(
-      <PrivacySettingsPage
-        accounts={[first, second]}
-        accountForm={first}
-        remoteImageTrusts={[]}
-        onAccountFormChange={() => undefined}
-        onSelectAccount={select}
-        onDeleteRemoteImageTrust={() => undefined}
-      />,
-    );
-    fireEvent.click(screen.getByLabelText('配置账号'));
-    fireEvent.click(screen.getByRole('option', { name: /home@example\.com/ }));
-    expect(select).toHaveBeenCalledWith(second);
+    renderPage(first, [], undefined, [first, second]);
+    expect(screen.queryByLabelText('配置账号')).toBeNull();
   });
 
   it('renders trust items with scope, value, created date and remove button', () => {
@@ -113,8 +99,8 @@ describe('PrivacySettingsPage', () => {
     const navigate = () => undefined;
     const spy = vi.fn(navigate);
     renderPage(makeAccount(), [], spy);
-    expect(screen.getByText(/可能会把邮件内容发送到外部 AI 服务/)).not.toBeNull();
-    fireEvent.click(screen.getByRole('button', { name: /前往 AI 服务设置/ }));
+    expect(screen.getByText(/可能把邮件内容发送到你配置的外部服务/)).not.toBeNull();
+    fireEvent.click(screen.getByRole('button', { name: /AI 与集成/ }));
     expect(spy).toHaveBeenCalledOnce();
   });
 });

--- a/src/components/settings/pages/SendingSettingsPage.tsx
+++ b/src/components/settings/pages/SendingSettingsPage.tsx
@@ -4,8 +4,6 @@ import {
 } from '../../../app/appConfig';
 import { CustomSelect } from '../accounts/CustomSelect';
 import {
-  SettingsBadge,
-  SettingsField,
   SettingsRow,
   SettingsSection,
 } from '../shared';
@@ -21,32 +19,27 @@ export default function SendingSettingsPage({
 }: SendingSettingsPageProps) {
   return (
     <SettingsSection
-      title="发送与撤回"
-      description="发送后短暂保留在发件箱，误发时可立即撤回到草稿箱"
-      badge={
-        <SettingsBadge tone={sendUndoDelaySeconds > 0 ? 'info' : 'neutral'}>
-          {sendUndoDelaySeconds > 0 ? `${sendUndoDelaySeconds} 秒` : '已关闭'}
-        </SettingsBadge>
-      }
+      title="发送"
+      description="减少误发，不增加额外操作。"
       dataSection="sending"
     >
       <SettingsRow
-        title="撤销发送延迟"
-        description="倒计时结束后自动进入 SMTP 后台任务，应用重启后仍会继续。"
+        title="撤销发送"
+        description="发送后保留一小段时间，期间可撤回到草稿。"
         control={
-          <SettingsField label="延迟时间">
+          <div className="settings-inline-select" aria-label="撤销发送延迟">
             <CustomSelect
               dense
               value={String(sendUndoDelaySeconds)}
-              options={sendUndoDelayOptions.map((o) => ({ value: String(o.value), label: o.label }))}
-              onChange={(val) => onSendUndoDelayChange(Number(val) as SendUndoDelaySeconds)}
+              options={sendUndoDelayOptions.map((option) => ({
+                value: String(option.value),
+                label: option.value === 0 ? '关闭' : option.label,
+              }))}
+              onChange={(value) => onSendUndoDelayChange(Number(value) as SendUndoDelaySeconds)}
             />
-          </SettingsField>
+          </div>
         }
       />
-      <p className="st-field-hint">
-        “发件箱”用于手动排队或稍后发送；“发送”按钮使用这里设置的撤销延迟。
-      </p>
     </SettingsSection>
   );
 }

--- a/src/components/settings/settings-v3.css
+++ b/src/components/settings/settings-v3.css
@@ -1,4 +1,4 @@
-/* Settings popup polish — compact, scope-first, low-chrome preferences UI. */
+/* Settings popup polish — compact, low-chrome, preference-first. */
 
 .settings-backdrop {
   --st-sidebar-width: 188px;
@@ -46,7 +46,7 @@
   border-radius: 7px;
 }
 
-/* Sidebar: one calm hierarchy. Search is for real settings, not only pages. */
+/* Sidebar */
 .settings-modal[data-ui="settings-v3"] .settings-nav {
   padding: 10px 8px 12px;
 }
@@ -59,13 +59,13 @@
   padding-top: 2px;
 }
 
-.settings-nav-list {
+.settings-nav-list,
+.settings-search-results {
   display: grid;
   gap: 2px;
 }
 
 .settings-modal[data-ui="settings-v3"] .settings-nav-list > button {
-  position: relative;
   min-height: 34px;
   display: flex;
   align-items: center;
@@ -93,11 +93,6 @@
   color: var(--st-accent);
 }
 
-.settings-search-results {
-  display: grid;
-  gap: 2px;
-}
-
 .settings-search-results .settings-nav-match-count {
   display: block;
   padding: 4px 8px 6px;
@@ -113,8 +108,8 @@
   padding: 8px 9px;
   border: 0;
   border-radius: 7px;
-  background: transparent;
   color: var(--st-text);
+  background: transparent;
   text-align: left;
 }
 
@@ -148,7 +143,7 @@
   100% { box-shadow: 0 0 0 0 transparent; }
 }
 
-/* Only account settings keep a secondary workspace navigation. */
+/* Account workspace: the only secondary navigation in Settings. */
 .settings-account-workspace {
   flex: 0 0 auto;
   border-bottom: 1px solid var(--st-border);
@@ -186,6 +181,28 @@
   font-size: 11px;
 }
 
+.settings-account-current {
+  min-width: 0;
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+}
+
+.settings-account-current small {
+  flex: 0 0 auto;
+  color: var(--st-text-tertiary);
+  font-size: 10px;
+}
+
+.settings-account-current strong {
+  overflow: hidden;
+  color: var(--st-text-secondary);
+  font-size: 11px;
+  font-weight: 500;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 .settings-account-connection-state {
   max-width: 300px;
   overflow: hidden;
@@ -196,14 +213,12 @@
 }
 
 .settings-context-tabs {
-  min-width: 0;
   min-height: 36px;
   display: flex;
   align-items: end;
   gap: 2px;
   padding: 0 18px;
   overflow-x: auto;
-  overflow-y: hidden;
   scrollbar-width: none;
 }
 
@@ -223,16 +238,15 @@
   box-shadow: none;
   font-size: 11px;
   font-weight: 500;
-  white-space: nowrap;
 }
 
-.settings-context-tabs > button:hover:not(:disabled) {
+.settings-context-tabs > button:hover:not(:disabled),
+.settings-context-tabs > button.active {
   color: var(--st-text);
   background: transparent;
 }
 
 .settings-context-tabs > button.active {
-  color: var(--st-text);
   font-weight: 600;
 }
 
@@ -252,7 +266,7 @@
   cursor: not-allowed;
 }
 
-/* Page hierarchy: one compact page heading, then flat sections. */
+/* Page hierarchy */
 .settings-modal[data-ui="settings-v3"] .settings-content {
   display: flex;
   flex-direction: column;
@@ -312,11 +326,11 @@
   line-height: 1.38;
 }
 
-.settings-modal[data-ui="settings-v3"] .st-notice:not(.danger):not(.warning) {
-  padding-block: 8px;
+.settings-inline-select {
+  width: 136px;
 }
 
-/* Closing a dirty explicit-save page should never silently discard work. */
+/* Dirty-close guard */
 .settings-discard-confirm {
   position: absolute;
   z-index: 20;
@@ -340,15 +354,8 @@
   gap: 2px;
 }
 
-.settings-discard-confirm strong {
-  color: var(--st-text);
-  font-size: 11px;
-}
-
-.settings-discard-confirm small {
-  color: var(--st-text-tertiary);
-  font-size: 10px;
-}
+.settings-discard-confirm strong { color: var(--st-text); font-size: 11px; }
+.settings-discard-confirm small { color: var(--st-text-tertiary); font-size: 10px; }
 
 .settings-discard-confirm > div {
   flex: 0 0 auto;
@@ -372,30 +379,16 @@
 }
 
 /* Account overview */
-.settings-account-overview {
-  display: grid;
-  gap: 12px;
-}
-
+.settings-account-overview { display: grid; gap: 12px; }
 .settings-account-overview-grid {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: 12px;
 }
+.settings-account-row.active { background: var(--st-accent-soft); }
+.settings-account-row.active .settings-account-row-icon { color: var(--st-accent); }
 
-.settings-account-row-main[aria-pressed="true"] {
-  color: var(--st-text);
-}
-
-.settings-account-row.active {
-  background: var(--st-accent-soft);
-}
-
-.settings-account-row.active .settings-account-row-icon {
-  color: var(--st-accent);
-}
-
-/* Progressive disclosure for advanced notification and AI controls. */
+/* Progressive disclosure */
 .settings-disclosure {
   border-top: 1px solid var(--st-border);
 }
@@ -416,21 +409,9 @@
   list-style: none;
 }
 
-.settings-disclosure > summary::-webkit-details-marker {
-  display: none;
-}
-
-.settings-disclosure > summary > span {
-  min-width: 0;
-  display: grid;
-  gap: 2px;
-}
-
-.settings-disclosure > summary strong {
-  font-size: 12px;
-  font-weight: 600;
-}
-
+.settings-disclosure > summary::-webkit-details-marker { display: none; }
+.settings-disclosure > summary > span { min-width: 0; display: grid; gap: 2px; }
+.settings-disclosure > summary strong { font-size: 12px; font-weight: 600; }
 .settings-disclosure > summary small,
 .settings-disclosure > summary em {
   color: var(--st-text-tertiary);
@@ -449,30 +430,22 @@
   transition: transform 140ms ease;
 }
 
-.settings-disclosure[open] > summary::after {
-  transform: rotate(270deg);
+.settings-disclosure[open] > summary::after { transform: rotate(270deg); }
+.settings-disclosure-body { padding: 4px 0 14px; }
+.settings-ai-advanced .settings-disclosure-body { gap: 12px; padding-top: 8px; }
+.settings-ai-actions { margin-top: 2px; padding-top: 14px; border-top: 1px solid var(--st-border); }
+
+.settings-connection-diagnostics .settings-save-verify-stages {
+  padding-inline: 0;
 }
 
-.settings-disclosure-body {
-  padding: 4px 0 14px;
+.settings-technical-details summary {
+  color: var(--st-text-secondary);
+  font-size: 11px;
+  cursor: pointer;
 }
 
-.settings-ai-advanced .settings-disclosure-body {
-  gap: 12px;
-  padding-top: 8px;
-}
-
-.settings-ai-actions {
-  margin-top: 2px;
-  padding-top: 14px;
-  border-top: 1px solid var(--st-border);
-}
-
-.settings-inline-select {
-  width: 136px;
-}
-
-/* Appearance is the one place where visual option tiles improve scanning. */
+/* Appearance previews */
 .settings-modal[data-ui="settings-v3"] .settings-theme-options {
   display: grid;
   grid-template-columns: repeat(3, minmax(0, 1fr));
@@ -496,7 +469,6 @@
 }
 
 .settings-modal[data-ui="settings-v3"] .settings-theme-option:hover {
-  border-color: var(--st-border-strong);
   background: var(--st-surface);
 }
 
@@ -536,21 +508,10 @@
   background: color-mix(in srgb, var(--st-text-tertiary) 20%, transparent);
 }
 
-.settings-theme-preview-content i:nth-child(2) {
-  width: 78%;
-}
-
-.settings-theme-preview-content i:nth-child(3) {
-  width: 58%;
-}
-
-.settings-theme-option[data-theme-mode="light"] .settings-theme-option-preview {
-  background: #f4f5f7;
-}
-
-.settings-theme-option[data-theme-mode="dark"] .settings-theme-option-preview {
-  background: #202329;
-}
+.settings-theme-preview-content i:nth-child(2) { width: 78%; }
+.settings-theme-preview-content i:nth-child(3) { width: 58%; }
+.settings-theme-option[data-theme-mode="light"] .settings-theme-option-preview { background: #f4f5f7; }
+.settings-theme-option[data-theme-mode="dark"] .settings-theme-option-preview { background: #202329; }
 
 .settings-theme-option-footer {
   min-width: 0;
@@ -587,12 +548,8 @@
   opacity: 1;
 }
 
-/* Temporary structural guards for legacy operational panels. Remove once their render paths are split. */
+/* Legacy data diagnostics stay out of the normal preferences surface. */
 .settings-modal[data-ui="settings-v3"] .settings-data-safety > .st-section:has(.settings-endpoint-grid) {
-  display: none;
-}
-
-.settings-modal[data-ui="settings-v3"] .settings-sync-stack > .st-section:last-child {
   display: none;
 }
 
@@ -604,17 +561,9 @@
     border-radius: 12px;
   }
 
-  .settings-account-workspace-topline {
-    padding-inline: 14px;
-  }
-
-  .settings-account-picker select {
-    max-width: 260px;
-  }
-
-  .settings-context-tabs {
-    padding-inline: 10px;
-  }
+  .settings-account-workspace-topline { padding-inline: 14px; }
+  .settings-account-picker select { max-width: 260px; }
+  .settings-context-tabs { padding-inline: 10px; }
 }
 
 @media (max-width: 640px) {
@@ -625,53 +574,26 @@
     border-radius: 0;
   }
 
-  .settings-account-workspace-topline {
-    display: none;
-  }
-
-  .settings-context-tabs {
-    min-height: 38px;
-    padding-inline: 8px;
-  }
-
-  .settings-context-tabs > button {
-    min-height: 37px;
-  }
-
+  .settings-account-workspace-topline { display: none; }
+  .settings-context-tabs { min-height: 38px; padding-inline: 8px; }
+  .settings-context-tabs > button { min-height: 37px; }
   .settings-modal[data-ui="settings-v3"] .settings-page-header {
     min-height: 52px;
     padding: 11px 16px 9px;
   }
-
   .settings-modal[data-ui="settings-v3"] .settings-page-content {
     gap: 16px;
     padding: 12px 16px 22px;
   }
-
   .settings-account-overview-grid,
-  .settings-modal[data-ui="settings-v3"] .settings-theme-options {
-    grid-template-columns: 1fr;
-  }
-
+  .settings-modal[data-ui="settings-v3"] .settings-theme-options { grid-template-columns: 1fr; }
   .settings-modal[data-ui="settings-v3"] .settings-theme-option {
     min-height: 92px;
     grid-template-columns: 100px minmax(0, 1fr);
     grid-template-rows: 1fr;
   }
-
-  .settings-theme-option-preview {
-    margin: 8px 0 8px 8px;
-  }
-
-  .settings-theme-option-footer {
-    padding-inline: 10px;
-  }
-
-  .settings-discard-confirm {
-    right: 8px;
-    left: 8px;
-    width: auto;
-  }
+  .settings-theme-option-preview { margin: 8px 0 8px 8px; }
+  .settings-discard-confirm { right: 8px; left: 8px; width: auto; }
 }
 
 @media (prefers-reduced-motion: reduce) {
@@ -679,8 +601,5 @@
     animation: none;
     box-shadow: 0 0 0 2px var(--st-accent);
   }
-
-  .settings-disclosure > summary::after {
-    transition: none;
-  }
+  .settings-disclosure > summary::after { transition: none; }
 }

--- a/src/components/settings/settings-v3.css
+++ b/src/components/settings/settings-v3.css
@@ -168,17 +168,28 @@
   font-size: 10px;
 }
 
-.settings-account-picker select {
+.settings-account-picker .custom-select-menu {
   min-width: 180px;
   max-width: 330px;
+}
+
+.settings-account-picker .custom-select-summary {
   height: 28px;
-  padding: 0 24px 0 8px;
-  border: 1px solid var(--st-border);
+  min-height: 28px;
+  padding-inline: 8px;
   border-radius: 7px;
   color: var(--st-text);
   background: var(--st-surface);
   font: inherit;
   font-size: 11px;
+}
+
+.settings-account-picker .custom-select-summary strong {
+  font-size: 11px;
+}
+
+.settings-account-picker .custom-select-summary small {
+  font-size: 10px;
 }
 
 .settings-account-current {
@@ -562,7 +573,7 @@
   }
 
   .settings-account-workspace-topline { padding-inline: 14px; }
-  .settings-account-picker select { max-width: 260px; }
+  .settings-account-picker .custom-select-menu { max-width: 260px; }
   .settings-context-tabs { padding-inline: 10px; }
 }
 

--- a/src/components/settings/settings-v3.css
+++ b/src/components/settings/settings-v3.css
@@ -1,86 +1,210 @@
-/* Settings IA V3 — scope-first navigation and desktop density polish. */
+/* Settings popup polish — compact, scope-first, low-chrome preferences UI. */
 
 .settings-backdrop {
-  --st-sidebar-width: 196px;
-  --st-content-max-width: 780px;
+  --st-sidebar-width: 188px;
+  --st-content-max-width: 700px;
 }
 
 .settings-modal[data-ui="settings-v3"] {
-  width: min(1040px, calc(100vw - 40px));
-  height: min(760px, calc(100dvh - 40px));
+  width: min(920px, calc(100vw - 48px));
+  height: min(680px, calc(100dvh - 48px));
+  border-radius: 14px;
 }
 
 .settings-modal[data-ui="settings-v3"][data-page-layout="compact"] {
-  height: min(620px, calc(100dvh - 40px));
+  width: min(880px, calc(100vw - 48px));
+  height: min(580px, calc(100dvh - 48px));
 }
 
 .settings-modal[data-ui="settings-v3"] .settings-main-header {
   min-height: 48px;
-  padding-inline: 16px 12px;
+  padding-inline: 16px 10px;
 }
 
 .settings-modal[data-ui="settings-v3"] .settings-title-copy strong {
   font-size: 15px;
+  letter-spacing: -.01em;
 }
 
-.settings-modal[data-ui="settings-v3"] .settings-title-copy small {
-  font-size: 11px;
+.settings-modal[data-ui="settings-v3"] .settings-header-actions {
+  gap: 6px;
 }
 
+.settings-modal[data-ui="settings-v3"] .settings-header-button {
+  min-height: 30px;
+  padding-inline: 10px;
+  border-radius: 7px;
+}
+
+.settings-modal[data-ui="settings-v3"] .settings-header-button:disabled {
+  opacity: .5;
+}
+
+.settings-modal[data-ui="settings-v3"] .settings-close-button {
+  width: 30px;
+  height: 30px;
+  border-radius: 7px;
+}
+
+/* Sidebar: one calm hierarchy. Search is for real settings, not only pages. */
 .settings-modal[data-ui="settings-v3"] .settings-nav {
-  padding: 12px 8px 14px;
+  padding: 10px 8px 12px;
 }
 
 .settings-modal[data-ui="settings-v3"] .settings-nav-search {
   margin-bottom: 8px;
 }
 
-.settings-modal[data-ui="settings-v3"] .settings-nav .settings-nav-group {
-  margin: 12px 10px 5px;
-  font-size: 10px;
-  letter-spacing: .02em;
+.settings-modal[data-ui="settings-v3"] .settings-nav-scroll {
+  padding-top: 2px;
 }
 
-.settings-modal[data-ui="settings-v3"] .settings-nav-section > button {
+.settings-nav-list {
+  display: grid;
+  gap: 2px;
+}
+
+.settings-modal[data-ui="settings-v3"] .settings-nav-list > button {
+  position: relative;
   min-height: 34px;
-  gap: 9px;
-  padding-inline: 9px;
-}
-
-.settings-modal[data-ui="settings-v3"] .settings-nav-section > button.active {
-  background: var(--st-accent-soft);
-  color: var(--st-text);
-}
-
-.settings-modal[data-ui="settings-v3"] .settings-nav-section > button.active::before {
-  content: '';
-  position: absolute;
-  left: 0;
-  width: 2px;
-  height: 18px;
-  border-radius: 999px;
-  background: var(--st-accent);
-}
-
-.settings-modal[data-ui="settings-v3"] .settings-content {
   display: flex;
-  flex-direction: column;
-  min-height: 0;
+  align-items: center;
+  gap: 9px;
+  width: 100%;
+  padding: 0 9px;
+  border: 0;
+  border-radius: 7px;
+  color: var(--st-text-secondary);
+  background: transparent;
+  text-align: left;
+}
+
+.settings-modal[data-ui="settings-v3"] .settings-nav-list > button:hover {
+  color: var(--st-text);
+  background: var(--st-surface-muted);
+}
+
+.settings-modal[data-ui="settings-v3"] .settings-nav-list > button.active {
+  color: var(--st-text);
+  background: var(--st-accent-soft);
+}
+
+.settings-modal[data-ui="settings-v3"] .settings-nav-list > button.active .settings-nav-icon {
+  color: var(--st-accent);
+}
+
+.settings-search-results {
+  display: grid;
+  gap: 2px;
+}
+
+.settings-search-results .settings-nav-match-count {
+  display: block;
+  padding: 4px 8px 6px;
+  color: var(--st-text-tertiary);
+  font-size: 10px;
+}
+
+.settings-search-result {
+  min-width: 0;
+  display: grid;
+  gap: 2px;
+  width: 100%;
+  padding: 8px 9px;
+  border: 0;
+  border-radius: 7px;
+  background: transparent;
+  color: var(--st-text);
+  text-align: left;
+}
+
+.settings-search-result:hover {
+  background: var(--st-surface-muted);
+}
+
+.settings-search-result strong,
+.settings-search-result small {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.settings-search-result strong {
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.settings-search-result small {
+  color: var(--st-text-tertiary);
+  font-size: 10px;
+}
+
+.settings-search-hit {
+  animation: settings-search-hit 1.2s ease-out;
+}
+
+@keyframes settings-search-hit {
+  0%, 35% { box-shadow: 0 0 0 2px var(--st-accent); }
+  100% { box-shadow: 0 0 0 0 transparent; }
+}
+
+/* Only account settings keep a secondary workspace navigation. */
+.settings-account-workspace {
+  flex: 0 0 auto;
+  border-bottom: 1px solid var(--st-border);
+  background: var(--st-canvas);
+}
+
+.settings-account-workspace-topline {
+  min-height: 42px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 6px 22px 2px;
+}
+
+.settings-account-picker {
+  min-width: 0;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  color: var(--st-text-tertiary);
+  font-size: 10px;
+}
+
+.settings-account-picker select {
+  min-width: 180px;
+  max-width: 330px;
+  height: 28px;
+  padding: 0 24px 0 8px;
+  border: 1px solid var(--st-border);
+  border-radius: 7px;
+  color: var(--st-text);
+  background: var(--st-surface);
+  font: inherit;
+  font-size: 11px;
+}
+
+.settings-account-connection-state {
+  max-width: 300px;
+  overflow: hidden;
+  color: var(--st-text-tertiary);
+  font-size: 10px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .settings-context-tabs {
-  flex: 0 0 auto;
   min-width: 0;
-  min-height: 42px;
+  min-height: 36px;
   display: flex;
   align-items: end;
   gap: 2px;
-  padding: 0 22px;
+  padding: 0 18px;
   overflow-x: auto;
   overflow-y: hidden;
   scrollbar-width: none;
-  border-bottom: 1px solid var(--st-border);
-  background: var(--st-canvas);
 }
 
 .settings-context-tabs::-webkit-scrollbar {
@@ -90,14 +214,14 @@
 .settings-context-tabs > button {
   position: relative;
   flex: 0 0 auto;
-  min-height: 41px;
-  padding: 0 9px;
+  min-height: 35px;
+  padding: 0 8px;
   border: 0;
   border-radius: 0;
   color: var(--st-text-secondary);
   background: transparent;
   box-shadow: none;
-  font-size: 12px;
+  font-size: 11px;
   font-weight: 500;
   white-space: nowrap;
 }
@@ -116,7 +240,7 @@
   content: '';
   position: absolute;
   right: 8px;
-  bottom: -1px;
+  bottom: 0;
   left: 8px;
   height: 2px;
   border-radius: 999px 999px 0 0;
@@ -124,8 +248,15 @@
 }
 
 .settings-context-tabs > button:disabled {
-  opacity: .42;
+  opacity: .4;
   cursor: not-allowed;
+}
+
+/* Page hierarchy: one compact page heading, then flat sections. */
+.settings-modal[data-ui="settings-v3"] .settings-content {
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
 }
 
 .settings-modal[data-ui="settings-v3"] .settings-page {
@@ -134,70 +265,122 @@
 }
 
 .settings-modal[data-ui="settings-v3"] .settings-page-header {
-  min-height: 62px;
-  padding: 13px 24px 11px;
+  position: relative;
+  top: auto;
+  min-height: 54px;
+  padding: 14px 22px 10px;
+  background: var(--st-canvas);
 }
 
 .settings-modal[data-ui="settings-v3"] .settings-page-heading {
-  gap: 3px;
+  gap: 2px;
 }
 
 .settings-modal[data-ui="settings-v3"] .settings-page-heading h2 {
   font-size: 18px;
+  letter-spacing: -.015em;
 }
 
 .settings-modal[data-ui="settings-v3"] .settings-page-heading p {
-  font-size: 12px;
+  max-width: 620px;
+  font-size: 11px;
   line-height: 1.4;
 }
 
 .settings-modal[data-ui="settings-v3"] .settings-page-content {
-  gap: 22px;
-  padding: 20px 24px 28px;
+  gap: 18px;
+  padding: 14px 22px 24px;
 }
 
 .settings-modal[data-ui="settings-v3"] .st-section-body {
-  margin-top: 10px;
+  margin-top: 8px;
 }
 
 .settings-modal[data-ui="settings-v3"] .st-subsection {
-  gap: 10px;
-  padding-top: 16px;
+  gap: 9px;
+  padding-top: 14px;
 }
 
 .settings-modal[data-ui="settings-v3"] :is(.st-row, .st-switch) {
-  min-height: 44px;
-  padding-block: 10px;
+  min-height: 42px;
+  padding-block: 9px;
 }
 
 .settings-modal[data-ui="settings-v3"] .st-section-heading small,
 .settings-modal[data-ui="settings-v3"] .st-row-copy small,
 .settings-modal[data-ui="settings-v3"] .st-switch small {
-  line-height: 1.4;
+  line-height: 1.38;
 }
 
 .settings-modal[data-ui="settings-v3"] .st-notice:not(.danger):not(.warning) {
-  padding-block: 9px;
+  padding-block: 8px;
 }
 
-/* Account overview becomes the account workspace landing page rather than a dialog launcher. */
+/* Closing a dirty explicit-save page should never silently discard work. */
+.settings-discard-confirm {
+  position: absolute;
+  z-index: 20;
+  top: 52px;
+  right: 12px;
+  width: min(330px, calc(100% - 24px));
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 10px 10px 10px 12px;
+  border: 1px solid var(--st-border);
+  border-radius: 10px;
+  background: var(--st-surface);
+  box-shadow: 0 12px 36px rgba(0, 0, 0, .16);
+}
+
+.settings-discard-confirm > span {
+  min-width: 0;
+  display: grid;
+  gap: 2px;
+}
+
+.settings-discard-confirm strong {
+  color: var(--st-text);
+  font-size: 11px;
+}
+
+.settings-discard-confirm small {
+  color: var(--st-text-tertiary);
+  font-size: 10px;
+}
+
+.settings-discard-confirm > div {
+  flex: 0 0 auto;
+  display: flex;
+  gap: 4px;
+}
+
+.settings-discard-confirm button {
+  min-height: 28px;
+  padding: 0 8px;
+  border: 0;
+  border-radius: 6px;
+  color: var(--st-text-secondary);
+  background: var(--st-surface-muted);
+  font-size: 10px;
+}
+
+.settings-discard-confirm button.danger {
+  color: var(--st-danger);
+  background: var(--st-danger-soft);
+}
+
+/* Account overview */
 .settings-account-overview {
   display: grid;
-  gap: 14px;
+  gap: 12px;
 }
 
 .settings-account-overview-grid {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: 12px;
-}
-
-.settings-account-quick-links {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 6px;
-  padding-top: 12px;
-  border-top: 1px solid var(--st-border);
 }
 
 .settings-account-row-main[aria-pressed="true"] {
@@ -212,7 +395,199 @@
   color: var(--st-accent);
 }
 
-/* V3 keeps operational / diagnostic surfaces out of normal preference pages. */
+/* Progressive disclosure for advanced notification and AI controls. */
+.settings-disclosure {
+  border-top: 1px solid var(--st-border);
+}
+
+.settings-disclosure:last-child {
+  border-bottom: 1px solid var(--st-border);
+}
+
+.settings-disclosure > summary {
+  min-height: 48px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 8px 2px;
+  color: var(--st-text);
+  cursor: pointer;
+  list-style: none;
+}
+
+.settings-disclosure > summary::-webkit-details-marker {
+  display: none;
+}
+
+.settings-disclosure > summary > span {
+  min-width: 0;
+  display: grid;
+  gap: 2px;
+}
+
+.settings-disclosure > summary strong {
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.settings-disclosure > summary small,
+.settings-disclosure > summary em {
+  color: var(--st-text-tertiary);
+  font-size: 10px;
+  font-style: normal;
+  font-weight: 400;
+}
+
+.settings-disclosure > summary::after {
+  content: '›';
+  flex: 0 0 auto;
+  color: var(--st-text-tertiary);
+  font-size: 18px;
+  line-height: 1;
+  transform: rotate(90deg);
+  transition: transform 140ms ease;
+}
+
+.settings-disclosure[open] > summary::after {
+  transform: rotate(270deg);
+}
+
+.settings-disclosure-body {
+  padding: 4px 0 14px;
+}
+
+.settings-ai-advanced .settings-disclosure-body {
+  gap: 12px;
+  padding-top: 8px;
+}
+
+.settings-ai-actions {
+  margin-top: 2px;
+  padding-top: 14px;
+  border-top: 1px solid var(--st-border);
+}
+
+.settings-inline-select {
+  width: 136px;
+}
+
+/* Appearance is the one place where visual option tiles improve scanning. */
+.settings-modal[data-ui="settings-v3"] .settings-theme-options {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 10px;
+}
+
+.settings-modal[data-ui="settings-v3"] .settings-theme-option {
+  min-width: 0;
+  min-height: 118px;
+  display: grid;
+  grid-template-columns: 1fr;
+  grid-template-rows: 78px 1fr;
+  gap: 0;
+  padding: 0;
+  overflow: hidden;
+  border: 1px solid var(--st-border);
+  border-radius: 10px;
+  color: var(--st-text-secondary);
+  background: var(--st-surface);
+  text-align: left;
+}
+
+.settings-modal[data-ui="settings-v3"] .settings-theme-option:hover {
+  border-color: var(--st-border-strong);
+  background: var(--st-surface);
+}
+
+.settings-modal[data-ui="settings-v3"] .settings-theme-option.active {
+  border-color: var(--st-accent);
+  background: var(--st-surface);
+  box-shadow: 0 0 0 1px var(--st-accent);
+}
+
+.settings-theme-option-preview {
+  display: grid;
+  grid-template-columns: 26px 1fr;
+  gap: 7px;
+  margin: 10px 10px 0;
+  padding: 8px;
+  overflow: hidden;
+  border-radius: 7px;
+  background: var(--st-surface-muted);
+}
+
+.settings-theme-preview-sidebar {
+  border-radius: 4px;
+  background: color-mix(in srgb, var(--st-text-tertiary) 22%, transparent);
+}
+
+.settings-theme-preview-content {
+  display: grid;
+  align-content: start;
+  gap: 6px;
+  padding-top: 2px;
+}
+
+.settings-theme-preview-content i {
+  display: block;
+  height: 6px;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--st-text-tertiary) 20%, transparent);
+}
+
+.settings-theme-preview-content i:nth-child(2) {
+  width: 78%;
+}
+
+.settings-theme-preview-content i:nth-child(3) {
+  width: 58%;
+}
+
+.settings-theme-option[data-theme-mode="light"] .settings-theme-option-preview {
+  background: #f4f5f7;
+}
+
+.settings-theme-option[data-theme-mode="dark"] .settings-theme-option-preview {
+  background: #202329;
+}
+
+.settings-theme-option-footer {
+  min-width: 0;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 8px 10px 9px;
+}
+
+.settings-theme-option-footer > span {
+  min-width: 0;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.settings-theme-option-footer strong {
+  overflow: hidden;
+  color: var(--st-text);
+  font-size: 11px;
+  font-weight: 600;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.settings-modal[data-ui="settings-v3"] .settings-theme-option-check {
+  flex: 0 0 auto;
+  color: var(--st-accent);
+  opacity: 0;
+}
+
+.settings-modal[data-ui="settings-v3"] .settings-theme-option.active .settings-theme-option-check {
+  opacity: 1;
+}
+
+/* Temporary structural guards for legacy operational panels. Remove once their render paths are split. */
 .settings-modal[data-ui="settings-v3"] .settings-data-safety > .st-section:has(.settings-endpoint-grid) {
   display: none;
 }
@@ -221,37 +596,24 @@
   display: none;
 }
 
-.settings-modal[data-ui="settings-v3"] .notification-rule-order {
-  display: none;
-}
-
-/* The primary AI provider already supports MCP. The second MCP panel duplicated the same endpoint/token model. */
-.settings-modal[data-ui="settings-v3"] [data-settings-section="ai-mcp-gateway"] {
-  display: none;
-}
-
-/* Reduce card-like emphasis inside AI; settings should read as one continuous preference surface. */
-.settings-modal[data-ui="settings-v3"] .ai-hero-card {
-  border: 0;
-  border-radius: 0;
-  background: transparent;
-  box-shadow: none;
-}
-
 @media (max-width: 900px) {
   .settings-modal[data-ui="settings-v3"],
   .settings-modal[data-ui="settings-v3"][data-page-layout="compact"] {
     width: calc(100vw - 16px);
     height: calc(100dvh - 16px);
+    border-radius: 12px;
   }
 
-  .settings-context-tabs {
-    min-height: 40px;
+  .settings-account-workspace-topline {
     padding-inline: 14px;
   }
 
-  .settings-context-tabs > button {
-    min-height: 39px;
+  .settings-account-picker select {
+    max-width: 260px;
+  }
+
+  .settings-context-tabs {
+    padding-inline: 10px;
   }
 }
 
@@ -260,23 +622,65 @@
   .settings-modal[data-ui="settings-v3"][data-page-layout="compact"] {
     width: 100vw;
     height: 100dvh;
+    border-radius: 0;
+  }
+
+  .settings-account-workspace-topline {
+    display: none;
   }
 
   .settings-context-tabs {
-    padding-inline: 10px;
+    min-height: 38px;
+    padding-inline: 8px;
+  }
+
+  .settings-context-tabs > button {
+    min-height: 37px;
   }
 
   .settings-modal[data-ui="settings-v3"] .settings-page-header {
-    min-height: 58px;
-    padding: 11px 16px 10px;
+    min-height: 52px;
+    padding: 11px 16px 9px;
   }
 
   .settings-modal[data-ui="settings-v3"] .settings-page-content {
-    gap: 18px;
-    padding: 16px 16px 24px;
+    gap: 16px;
+    padding: 12px 16px 22px;
   }
 
-  .settings-account-overview-grid {
+  .settings-account-overview-grid,
+  .settings-modal[data-ui="settings-v3"] .settings-theme-options {
     grid-template-columns: 1fr;
+  }
+
+  .settings-modal[data-ui="settings-v3"] .settings-theme-option {
+    min-height: 92px;
+    grid-template-columns: 100px minmax(0, 1fr);
+    grid-template-rows: 1fr;
+  }
+
+  .settings-theme-option-preview {
+    margin: 8px 0 8px 8px;
+  }
+
+  .settings-theme-option-footer {
+    padding-inline: 10px;
+  }
+
+  .settings-discard-confirm {
+    right: 8px;
+    left: 8px;
+    width: auto;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .settings-search-hit {
+    animation: none;
+    box-shadow: 0 0 0 2px var(--st-accent);
+  }
+
+  .settings-disclosure > summary::after {
+    transition: none;
   }
 }

--- a/src/components/settings/settingsNavigation.test.ts
+++ b/src/components/settings/settingsNavigation.test.ts
@@ -26,9 +26,9 @@ describe('settingsNavigation v3 information architecture', () => {
     }
   });
 
-  it('maps sending into the General workspace while preserving its own page title', () => {
-    expect(resolveSettingsNavigationSectionId('sending')).toBe('appearance');
-    expect(getSettingsNavigationContext('sending').item.label).toBe('通用');
+  it('keeps sending directly reachable while preserving its own page title', () => {
+    expect(resolveSettingsNavigationSectionId('sending')).toBe('sending');
+    expect(getSettingsNavigationContext('sending').item.label).toBe('发送');
     expect(getSettingsSectionPresentation('sending').label).toBe('发送');
   });
 
@@ -47,7 +47,7 @@ describe('settingsNavigation v3 information architecture', () => {
 
   it('puts the core destinations into deliberate groups', () => {
     expect(settingsNavigationGroups.find((group) => group.label === '常用')?.items.map((item) => item.id))
-      .toEqual(['appearance', 'accounts', 'notifications']);
+      .toEqual(['appearance', 'accounts', 'sending', 'notifications']);
     expect(settingsNavigationGroups.find((group) => group.label === '智能')?.items.map((item) => item.id))
       .toEqual(['ai']);
     expect(settingsNavigationGroups.find((group) => group.label === '效率工具')?.items.map((item) => item.id))

--- a/src/components/settings/settingsNavigation.ts
+++ b/src/components/settings/settingsNavigation.ts
@@ -5,6 +5,7 @@ import {
   Info,
   LayoutTemplate,
   ScanSearch,
+  Send,
   Settings2,
   Sparkles,
   UserRound,
@@ -65,10 +66,9 @@ export const accountScopedSections = new Set<SettingsSectionId>([
   'privacy',
 ]);
 
-export const generalScopedSections = new Set<SettingsSectionId>([
-  'appearance',
-  'sending',
-]);
+// Kept as an export for compatibility. General preferences no longer use a
+// second tab row; each primary destination is directly reachable.
+export const generalScopedSections = new Set<SettingsSectionId>();
 
 const sectionPresentation: Record<SettingsSectionId, Pick<SettingsNavigationItem, 'label' | 'description'>> = {
   accounts: {
@@ -97,7 +97,7 @@ const sectionPresentation: Record<SettingsSectionId, Pick<SettingsNavigationItem
   },
   appearance: {
     label: '通用',
-    description: '外观与日常发送偏好。',
+    description: '选择界面外观与主题。',
   },
   sending: {
     label: '发送',
@@ -143,7 +143,6 @@ export function getSettingsSectionPresentation(section: SettingsSectionId) {
 
 export function resolveSettingsNavigationSectionId(section: SettingsSectionId): SettingsSectionId {
   if (accountScopedSections.has(section)) return 'accounts';
-  if (generalScopedSections.has(section)) return 'appearance';
   return section;
 }
 
@@ -154,8 +153,8 @@ export const settingsNavigationGroups: SettingsNavigationGroup[] = [
       {
         id: 'appearance',
         label: '通用',
-        description: '外观与发送偏好。',
-        keywords: ['通用', '外观', '主题', '亮色', '暗色', '发送', '撤销发送', 'undo', 'theme', 'appearance'],
+        description: '界面外观与主题。',
+        keywords: ['通用', '外观', '主题', '亮色', '暗色', 'theme', 'appearance'],
         icon: Settings2,
       },
       {
@@ -168,6 +167,13 @@ export const settingsNavigationGroups: SettingsNavigationGroup[] = [
           '信任', '外部发件人',
         ],
         icon: UserRound,
+      },
+      {
+        id: 'sending',
+        label: '发送',
+        description: '撤销发送与发送行为。',
+        keywords: ['发送', '撤销发送', '撤回', 'undo', 'send'],
+        icon: Send,
       },
       {
         id: 'notifications',
@@ -251,8 +257,8 @@ export const settingsNavigationItems = settingsNavigationGroups.flatMap((group) 
 ));
 
 export const settingsSearchEntries: SettingsSearchEntry[] = [
-  { label: '界面外观', path: '通用 › 外观', section: 'appearance', target: 'appearance', keywords: ['主题', '系统', '亮色', '暗色', 'theme'] },
-  { label: '撤销发送', path: '通用 › 发送', section: 'sending', target: 'sending', keywords: ['发送延迟', '撤回', 'undo', '5秒', '10秒'] },
+  { label: '界面外观', path: '通用', section: 'appearance', target: 'appearance', keywords: ['主题', '系统', '亮色', '暗色', 'theme'] },
+  { label: '撤销发送', path: '发送', section: 'sending', target: 'sending', keywords: ['发送延迟', '撤回', 'undo', '5秒', '10秒'] },
   { label: '邮箱账号', path: '账号 › 概览', section: 'accounts', target: 'account-overview', keywords: ['添加账号', '删除账号', '邮箱', 'display name'] },
   { label: '获取新邮件', path: '账号 › 概览', section: 'accounts', target: 'account-overview', keywords: ['同步频率', '后台检查', 'sync'] },
   { label: '自动下载附件', path: '账号 › 概览', section: 'accounts', target: 'account-overview', keywords: ['附件', '自动下载', 'download'] },

--- a/src/components/settings/settingsNavigation.ts
+++ b/src/components/settings/settingsNavigation.ts
@@ -43,6 +43,14 @@ export type SettingsNavigationGroup = {
   items: SettingsNavigationItem[];
 };
 
+export type SettingsSearchEntry = {
+  label: string;
+  path: string;
+  section: SettingsSectionId;
+  keywords: string[];
+  target?: string;
+};
+
 export const devMode = typeof window !== 'undefined' &&
   (window.localStorage.getItem('better-email.dev-mode') === '1' ||
    import.meta.env.DEV ||
@@ -65,31 +73,31 @@ export const generalScopedSections = new Set<SettingsSectionId>([
 const sectionPresentation: Record<SettingsSectionId, Pick<SettingsNavigationItem, 'label' | 'description'>> = {
   accounts: {
     label: '账号',
-    description: '管理邮箱账号，并从这里进入服务器、登录、身份、同步和隐私设置。',
+    description: '管理邮箱账号与当前账号的常用行为。',
   },
   providers: {
     label: '服务器',
-    description: '配置服务商、收信协议以及 IMAP / POP3 / SMTP 服务器。',
+    description: '配置收信与发信服务器。',
   },
   auth: {
     label: '登录与安全',
-    description: '管理授权码、OAuth2 与当前邮箱的登录凭据。',
+    description: '管理授权码、OAuth2 与登录凭据。',
   },
   identities: {
     label: '身份与签名',
-    description: '管理发件显示名、别名、Reply-To 与签名。',
+    description: '管理发件身份、别名、Reply-To 与签名。',
   },
   sync: {
     label: '同步',
-    description: '查看当前邮箱的同步状态、文件夹映射与手动同步。',
+    description: '管理同步状态、文件夹映射与手动同步。',
   },
   privacy: {
     label: '隐私',
-    description: '控制当前邮箱的远程图片、外部发件人提示、链接保护与信任列表。',
+    description: '控制远程图片、外部发件人提示与信任列表。',
   },
   appearance: {
-    label: '外观',
-    description: '选择界面主题与系统外观跟随方式。',
+    label: '通用',
+    description: '外观与日常发送偏好。',
   },
   sending: {
     label: '发送',
@@ -97,31 +105,31 @@ const sectionPresentation: Record<SettingsSectionId, Pick<SettingsNavigationItem
   },
   notifications: {
     label: '通知',
-    description: '设置免打扰、VIP 发件人和各邮箱账号的提醒优先级。',
+    description: '管理提醒、免打扰、VIP 与账号优先级。',
   },
   ai: {
     label: 'AI 与集成',
-    description: '配置 AI 推理服务、MCP 连接与外部服务隐私授权。',
+    description: '配置 AI 服务、模型与隐私授权。',
   },
   backup: {
     label: '数据与存储',
-    description: '管理本地占用、附件缓存、下载位置以及备份与恢复。',
+    description: '管理本地占用、附件缓存、下载位置与备份。',
   },
   contacts: {
     label: '通讯录',
-    description: '管理联系人、VIP、别名以及联系人导入导出。',
+    description: '管理联系人、VIP、别名与导入导出。',
   },
   templates: {
     label: '模板',
-    description: '管理写信模板、分类、变量和常用模板。',
+    description: '管理写信模板、分类与变量。',
   },
   rules: {
     label: '自动化',
-    description: '按发件人、主题和内容自动处理新邮件。',
+    description: '按条件自动处理新邮件。',
   },
   'security-preview': {
     label: '安全预览',
-    description: '开发模式下检查 MIME、HTML 清洗、附件和远程资源。',
+    description: '开发模式下检查 MIME、HTML、附件与远程资源。',
   },
   about: {
     label: '关于',
@@ -176,7 +184,7 @@ export const settingsNavigationGroups: SettingsNavigationGroup[] = [
       {
         id: 'ai',
         label: 'AI 与集成',
-        description: 'AI 推理、MCP 与隐私授权。',
+        description: 'AI 服务、模型、MCP 与隐私授权。',
         keywords: ['ai', '人工智能', '翻译', '摘要', 'api', 'mcp', 'openai', '模型', 'key', '集成'],
         icon: Sparkles,
       },
@@ -241,6 +249,33 @@ export const settingsNavigationGroups: SettingsNavigationGroup[] = [
 export const settingsNavigationItems = settingsNavigationGroups.flatMap((group) => (
   group.items.map((item) => ({ ...item, groupLabel: group.label }))
 ));
+
+export const settingsSearchEntries: SettingsSearchEntry[] = [
+  { label: '界面外观', path: '通用 › 外观', section: 'appearance', target: 'appearance', keywords: ['主题', '系统', '亮色', '暗色', 'theme'] },
+  { label: '撤销发送', path: '通用 › 发送', section: 'sending', target: 'sending', keywords: ['发送延迟', '撤回', 'undo', '5秒', '10秒'] },
+  { label: '邮箱账号', path: '账号 › 概览', section: 'accounts', target: 'account-overview', keywords: ['添加账号', '删除账号', '邮箱', 'display name'] },
+  { label: '获取新邮件', path: '账号 › 概览', section: 'accounts', target: 'account-overview', keywords: ['同步频率', '后台检查', 'sync'] },
+  { label: '自动下载附件', path: '账号 › 概览', section: 'accounts', target: 'account-overview', keywords: ['附件', '自动下载', 'download'] },
+  { label: '跨邮箱发送风险提示', path: '账号 › 概览', section: 'accounts', target: 'account-overview', keywords: ['发送提醒', '跨账号', 'risk'] },
+  { label: '收信与发信服务器', path: '账号 › 服务器', section: 'providers', keywords: ['imap', 'pop3', 'smtp', '端口', 'ssl', 'tls'] },
+  { label: '登录凭据与授权码', path: '账号 › 登录与安全', section: 'auth', keywords: ['密码', '授权码', 'oauth', 'token'] },
+  { label: '发件身份与签名', path: '账号 › 身份与签名', section: 'identities', keywords: ['签名', '别名', 'reply-to', '显示名'] },
+  { label: '同步与文件夹映射', path: '账号 › 同步', section: 'sync', keywords: ['文件夹', '同步', 'imap folder'] },
+  { label: '远程图片与信任列表', path: '账号 › 隐私', section: 'privacy', keywords: ['图片', '隐私', '信任', '外部发件人'] },
+  { label: '只提醒 VIP', path: '通知', section: 'notifications', target: 'notifications', keywords: ['vip', '只提醒', '重点联系人'] },
+  { label: '免打扰时段', path: '通知', section: 'notifications', target: 'notifications', keywords: ['免打扰', '静音', '时间', 'dnd'] },
+  { label: '账号通知优先级', path: '通知 › 高级', section: 'notifications', target: 'notification-account-rules', keywords: ['重点账号', '静音账号', '优先提醒'] },
+  { label: 'VIP 发件人', path: '通知 › 高级', section: 'notifications', target: 'notification-vip-rules', keywords: ['发件人', 'vip', '域名'] },
+  { label: 'AI 功能', path: 'AI 与集成', section: 'ai', target: 'ai', keywords: ['翻译', '摘要', '模板生成', '人工智能'] },
+  { label: 'AI 服务与模型', path: 'AI 与集成', section: 'ai', target: 'ai-llm-provider', keywords: ['openai', '模型', 'mcp', 'api', 'llm'] },
+  { label: 'AI 连接参数', path: 'AI 与集成 › 高级连接', section: 'ai', target: 'ai-advanced', keywords: ['endpoint', 'api key', 'token', 'timeout', '端点'] },
+  { label: '联系人与 VIP', path: '通讯录', section: 'contacts', keywords: ['联系人', '通讯录', '别名', 'vip'] },
+  { label: '写信模板', path: '模板', section: 'templates', keywords: ['模板', '变量', '常用模板'] },
+  { label: '邮件自动化规则', path: '自动化', section: 'rules', keywords: ['规则', '过滤', '自动处理'] },
+  { label: '附件缓存与下载位置', path: '数据与存储', section: 'backup', keywords: ['缓存', '附件', '下载目录', '存储'] },
+  { label: '备份与恢复', path: '数据与存储', section: 'backup', keywords: ['备份', '恢复', '导入', '导出'] },
+  { label: '版本与更新', path: '关于', section: 'about', keywords: ['版本', '更新', 'github', 'license'] },
+];
 
 export const connectionSettingsSections = new Set<SettingsSectionId>([
   'accounts',

--- a/src/components/settings/settingsOverlayHandlers.ts
+++ b/src/components/settings/settingsOverlayHandlers.ts
@@ -18,6 +18,9 @@ import type { ProviderWritebackValidationStepId } from '../../app/providerWriteV
  * actually change instead of on every application tick.
  */
 export type SettingsHandlers = {
+  readonly accountOptions: Array<{ id: number; label: string; email: string }>;
+  readonly activeAccountId: number | null;
+  onSelectAccountId: (accountId: number) => void;
   onNavigate: (section: SettingsSectionId) => void;
   onClose: () => void;
   onTestConnection: () => void;
@@ -111,6 +114,20 @@ type OverlayRef = { current: SettingsOverlayProps };
 export function createSettingsHandlers(ref: OverlayRef): SettingsHandlers {
   const latest = (): SettingsOverlayProps => ref.current;
   return {
+    get accountOptions() {
+      return latest().accounts.map((account) => ({
+        id: account.id,
+        label: account.display_name || account.email,
+        email: account.email,
+      }));
+    },
+    get activeAccountId() {
+      return latest().accountForm?.id ?? null;
+    },
+    onSelectAccountId: (accountId) => {
+      const account = latest().accounts.find((candidate) => candidate.id === accountId);
+      if (account) latest().onSelectAccount(account);
+    },
     onNavigate: (section) => latest().onNavigate(section),
     onClose: () => latest().onClose(),
     onTestConnection: () => latest().onTestConnection(),


### PR DESCRIPTION
全面优化桌面设置中心：

- 收紧弹窗尺寸、层级与信息密度，保留弹窗式设置体验
- 主导航改为单层，只有账号保留二级工作区导航；账号子页去掉重复页面标题
- 设置搜索升级为具体设置项搜索，改用 Cmd/Ctrl+F；命中高级折叠项时自动展开并定位
- 账号工作区常驻当前账号，并支持直接切换；有未保存修改时禁止误切账号
- 账号保存/测试动作固定；未保存保护覆盖关闭按钮、Esc 与背景点击，并跨页面生效
- 账号概览移除重复快捷入口，连接诊断默认折叠
- 通知改为默认简单 + 优先级/VIP 渐进披露，并补空 VIP 风险提示
- AI 配置去工程面板化，MCP/Endpoint/Token/Timeout 收入高级连接
- 外观改为更直观的视觉主题选择器，发送设置去重
- 同步调度/写回/发件箱诊断仅开发模式展示
- 数据与存储的服务器诊断改为开发模式结构化渲染，不再依赖普通页面先渲染再隐藏

目标：不推翻现有设计系统，重点做减法、层级、交互一致性和高级感。