### PR TITLE
chore: add dependency and contributor bots

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -1,0 +1,17 @@
+{
+  "projectName": "better-email",
+  "projectOwner": "anYuJia",
+  "repoType": "github",
+  "repoHost": "https://github.com",
+  "files": [
+    "CONTRIBUTORS.md"
+  ],
+  "imageSize": 72,
+  "commit": false,
+  "commitConvention": "angular",
+  "contributorsPerLine": 7,
+  "contributorsSortAlphabetically": true,
+  "linkToUsage": true,
+  "skipCi": true,
+  "contributors": []
+}

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,56 @@
+version: 2
+
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "Asia/Shanghai"
+    open-pull-requests-limit: 5
+    groups:
+      npm-minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-major"
+
+  - package-ecosystem: "cargo"
+    directory: "/src-tauri"
+    schedule:
+      interval: "weekly"
+      day: "tuesday"
+      time: "09:00"
+      timezone: "Asia/Shanghai"
+    open-pull-requests-limit: 5
+    groups:
+      cargo-minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-major"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "wednesday"
+      time: "09:00"
+      timezone: "Asia/Shanghai"
+    open-pull-requests-limit: 5
+    groups:
+      actions-minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-major"

--- a/.github/workflows/dependency-snapshot.yml
+++ b/.github/workflows/dependency-snapshot.yml
@@ -1,0 +1,97 @@
+name: Dependency Snapshot
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - package.json
+      - src-tauri/Cargo.toml
+      - .github/workflows/dependency-snapshot.yml
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: dependency-snapshot-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  update:
+    if: github.actor != 'github-actions[bot]'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Generate dependency snapshot
+        shell: bash
+        run: |
+          mkdir -p docs
+          node --input-type=module <<'NODE' > docs/DEPENDENCY_STATUS.md
+          import fs from 'node:fs';
+
+          const pkg = JSON.parse(fs.readFileSync('package.json', 'utf8'));
+          const cargo = fs.readFileSync('src-tauri/Cargo.toml', 'utf8');
+
+          console.log('# Dependency Status');
+          console.log('');
+          console.log('> Generated automatically from the committed dependency manifests.');
+          console.log('');
+          console.log(`Better Email version: **${pkg.version}**`);
+          console.log('');
+          console.log('## Node.js dependencies');
+          console.log('');
+
+          for (const [group, dependencies] of [
+            ['Runtime', pkg.dependencies ?? {}],
+            ['Development', pkg.devDependencies ?? {}],
+          ]) {
+            console.log(`### ${group}`);
+            console.log('');
+            for (const [name, version] of Object.entries(dependencies).sort(([a], [b]) => a.localeCompare(b))) {
+              console.log(`- \`${name}\`: \`${version}\``);
+            }
+            console.log('');
+          }
+
+          console.log('## Rust dependencies');
+          console.log('');
+
+          let section = '';
+          for (const rawLine of cargo.split(/\r?\n/)) {
+            const line = rawLine.trim();
+            const sectionMatch = line.match(/^\[(.+)]$/);
+            if (sectionMatch) {
+              section = sectionMatch[1];
+              continue;
+            }
+            if (!section.includes('dependencies') || !line || line.startsWith('#') || !line.includes('=')) {
+              continue;
+            }
+            console.log(`- \`${line}\``);
+          }
+          NODE
+
+      - name: Commit snapshot when changed
+        shell: bash
+        run: |
+          if git diff --quiet -- docs/DEPENDENCY_STATUS.md; then
+            echo "Dependency snapshot is already current."
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add docs/DEPENDENCY_STATUS.md
+          git commit -m "docs: refresh dependency snapshot"
+          git push

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,19 @@
+ci:
+  autofix_prs: true
+  autofix_commit_msg: "chore(pre-commit): apply automatic fixes"
+  autoupdate_commit_msg: "chore(pre-commit): update hooks"
+  autoupdate_schedule: monthly
+
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v6.0.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-json
+      - id: check-yaml
+      - id: check-toml
+      - id: check-merge-conflict
+      - id: check-case-conflict
+      - id: mixed-line-ending
+        args: ["--fix=lf"]

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,0 +1,12 @@
+# Contributors ✨
+
+Thanks to everyone and every automation that improves Better Email.
+
+<!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
+<!-- prettier-ignore-start -->
+<!-- markdownlint-disable -->
+
+<!-- ALL-CONTRIBUTORS-LIST:END -->
+<!-- prettier-ignore-end -->
+
+This project follows the [all-contributors](https://allcontributors.org) specification. Contributions of any kind are welcome.

--- a/README.md
+++ b/README.md
@@ -210,5 +210,7 @@ Better Email 的界面目标不是“更炫”，而是 **更快、更稳、更�
   &nbsp;&nbsp;·&nbsp;&nbsp;
   <a href="https://github.com/anYuJia/better-email/issues">Report an issue</a>
   &nbsp;&nbsp;·&nbsp;&nbsp;
+  <a href="./CONTRIBUTORS.md">Contributors</a>
+  &nbsp;&nbsp;·&nbsp;&nbsp;
   <a href="./LICENSE">MIT License</a>
 </p>

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,48 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended",
+    ":dependencyDashboard"
+  ],
+  "timezone": "Asia/Shanghai",
+  "schedule": [
+    "before 8am on monday"
+  ],
+  "prHourlyLimit": 2,
+  "prConcurrentLimit": 5,
+  "enabledManagers": [
+    "npm",
+    "cargo",
+    "github-actions"
+  ],
+  "packageRules": [
+    {
+      "description": "Dependabot owns non-major updates for these ecosystems",
+      "matchManagers": [
+        "npm",
+        "cargo",
+        "github-actions"
+      ],
+      "matchUpdateTypes": [
+        "minor",
+        "patch",
+        "pin",
+        "digest",
+        "lockFileMaintenance"
+      ],
+      "enabled": false
+    },
+    {
+      "description": "Renovate owns major upgrades",
+      "matchManagers": [
+        "npm",
+        "cargo",
+        "github-actions"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "dependencyDashboardApproval": false
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- add Dependabot for npm, Cargo and GitHub Actions minor/patch updates
- add Renovate config for major dependency upgrades only
- add pre-commit.ci autofix/autoupdate hooks
- add All Contributors registry and configuration
- add a GitHub Actions dependency snapshot workflow that commits only when manifests change
- link CONTRIBUTORS.md from README

## Bot ownership

- Dependabot: patch/minor
- Renovate: major
- github-actions[bot]: generated dependency status
- pre-commit.ci: lightweight repository hygiene
- allcontributors[bot]: contributor registry

This split avoids duplicate Dependabot/Renovate PRs.