### PR TITLE
refactor: polish mobile mail UI to product-native density

### DIFF
--- a/src/components/messageListLayout.ts
+++ b/src/components/messageListLayout.ts
@@ -9,8 +9,8 @@ export type LayoutItem = { top: number; height: number };
  * 虚拟计算高度必须与实际渲染高度一致，否则滚动、选中、悬停会错位。
  */
 export const MESSAGE_ROW_HEIGHT = 82;
-/** Mobile retains the previously approved roomier touch row. */
-export const MOBILE_MESSAGE_ROW_HEIGHT = 88;
+/** Mobile keeps a comfortable touch target without wasting list density. */
+export const MOBILE_MESSAGE_ROW_HEIGHT = 76;
 export const GROUP_HEADER_HEIGHT = 30;
 /** 列表底部“已显示 N 封 / 加载更多”区域的高度，计入外层包裹总高度。 */
 export const LIST_FOOTER_HEIGHT = 40;

--- a/src/components/mobile/MobileInboxHeader.test.tsx
+++ b/src/components/mobile/MobileInboxHeader.test.tsx
@@ -26,14 +26,21 @@ const baseProps: ComponentProps<typeof MobileInboxHeader> = {
 };
 
 describe('MobileInboxHeader filter menu', () => {
-  it('reports the menu as expanded only while its popover is open', () => {
+  it('keeps filters behind one compact menu instead of a persistent tab row', () => {
     render(<MobileInboxHeader {...baseProps} />);
 
-    const trigger = screen.getByRole('button', { name: '更多筛选，当前：附件' });
+    expect(document.querySelector('.mobile-inbox-filter-row')).toBeNull();
+    expect(screen.getByText('12 封 · 附件')).toBeTruthy();
+
+    const trigger = screen.getByRole('button', { name: '筛选和列表，当前：附件' });
     expect(trigger.getAttribute('aria-expanded')).toBe('false');
 
     fireEvent.click(trigger);
     expect(trigger.getAttribute('aria-expanded')).toBe('true');
+    expect(screen.getByRole('menuitemradio', { name: '全部' })).toBeTruthy();
+    expect(screen.getByRole('menuitemradio', { name: '未读' })).toBeTruthy();
+    expect(screen.getByRole('menuitemradio', { name: '星标' })).toBeTruthy();
+    expect(screen.getByRole('menuitemradio', { name: '附件' })).toBeTruthy();
 
     fireEvent.click(screen.getByRole('menuitemradio', { name: '附件' }));
     expect(trigger.getAttribute('aria-expanded')).toBe('false');

--- a/src/components/mobile/MobileInboxHeader.tsx
+++ b/src/components/mobile/MobileInboxHeader.tsx
@@ -54,8 +54,8 @@ export default function MobileInboxHeader({
   searchOpen,
 }: MobileInboxHeaderProps) {
   const searchInputRef = useRef<HTMLInputElement | null>(null);
-  const listModeMenuTriggerRef = useRef<HTMLButtonElement | null>(null);
-  const [listModeMenu, setListModeMenu] = useState<{ x: number; y: number } | null>(null);
+  const filterMenuTriggerRef = useRef<HTMLButtonElement | null>(null);
+  const [filterMenu, setFilterMenu] = useState<{ x: number; y: number } | null>(null);
 
   useEffect(() => {
     if (!searchOpen) return;
@@ -68,19 +68,26 @@ export default function MobileInboxHeader({
   }
 
   const activeFilter = filters.find((item) => item.id === filter) ?? filters[0];
-  const listModeMenuItems: ContextMenuItem[] = [
-    {
-      id: 'mobile-filter-attachments',
-      label: '附件',
-      checked: filter === 'attachments',
-      selectionRole: 'radio',
-      onSelect: () => onFilterChange('attachments'),
-    },
+  const hasNonDefaultView = filter !== 'all' || listMode !== 'messages';
+  const secondarySummary = [
+    visibleListSummary,
+    filter !== 'all' ? activeFilter.label : '',
+    listMode === 'threads' ? '会话' : '',
+  ].filter(Boolean).join(' · ');
+  const filterMenuItems: ContextMenuItem[] = [
+    ...filters.map((item) => ({
+      id: `mobile-filter-${item.id}`,
+      label: item.label,
+      checked: filter === item.id,
+      selectionRole: 'radio' as const,
+      onSelect: () => onFilterChange(item.id),
+    })),
     {
       id: 'mobile-list-mode-messages',
       label: '邮件列表',
       checked: listMode === 'messages',
       selectionRole: 'radio',
+      separatorBefore: true,
       onSelect: onShowMessages,
     },
     {
@@ -143,18 +150,38 @@ export default function MobileInboxHeader({
           <Menu size={22} aria-hidden="true" />
         </button>
         <button type="button" className="mobile-inbox-title" onClick={onOpenMailbox}>
-          <strong>{currentViewLabel}</strong>
-          <span>{visibleListSummary}</span>
+          <span className="mobile-inbox-title-copy">
+            <strong>{currentViewLabel}</strong>
+            <small>{secondarySummary}</small>
+          </span>
           <ChevronDown size={15} aria-hidden="true" />
         </button>
         <div className="mobile-inbox-actions">
+          <button
+            ref={filterMenuTriggerRef}
+            type="button"
+            className={`mobile-header-icon mobile-filter-trigger${hasNonDefaultView ? ' active' : ''}`}
+            aria-label={`筛选和列表，当前：${activeFilter.label}${listMode === 'threads' ? '，会话列表' : ''}`}
+            aria-haspopup="menu"
+            aria-expanded={Boolean(filterMenu)}
+            onClick={(event) => {
+              if (filterMenu) {
+                setFilterMenu(null);
+                return;
+              }
+              const bounds = event.currentTarget.getBoundingClientRect();
+              setFilterMenu({ x: Math.max(8, bounds.right - 208), y: bounds.bottom + 4 });
+            }}
+          >
+            <SlidersHorizontal size={19} aria-hidden="true" />
+          </button>
           <button
             type="button"
             className="mobile-header-icon"
             aria-label="搜索邮件"
             onClick={onOpenSearch}
           >
-            <Search size={21} aria-hidden="true" />
+            <Search size={20} aria-hidden="true" />
           </button>
           <button
             type="button"
@@ -164,58 +191,21 @@ export default function MobileInboxHeader({
             disabled={isRefreshing}
             onClick={onRefresh}
           >
-            <RefreshCw size={19} aria-hidden="true" className={isRefreshing ? 'animate-spin' : ''} />
+            <RefreshCw size={18} aria-hidden="true" className={isRefreshing ? 'animate-spin' : ''} />
           </button>
         </div>
       </div>
-
-      <div className="mobile-inbox-filter-row" role="tablist" aria-label="邮件筛选">
-        {filters.slice(0, 3).map((item) => (
-          <button
-            key={item.id}
-            type="button"
-            role="tab"
-            aria-selected={filter === item.id}
-            className={filter === item.id ? 'active' : ''}
-            onClick={() => onFilterChange(item.id)}
-          >
-            {item.label}
-          </button>
-        ))}
-        <div className="mobile-inbox-filter-menu">
-          <button
-            ref={listModeMenuTriggerRef}
-            type="button"
-            className={filter === 'attachments' ? 'active' : ''}
-            aria-label={`更多筛选，当前：${activeFilter.label}`}
-            aria-haspopup="menu"
-            aria-expanded={Boolean(listModeMenu)}
-            onClick={(event) => {
-              if (listModeMenu) {
-                setListModeMenu(null);
-                return;
-              }
-              const bounds = event.currentTarget.getBoundingClientRect();
-              setListModeMenu({ x: bounds.right - 188, y: bounds.bottom + 6 });
-            }}
-          >
-            <SlidersHorizontal size={16} aria-hidden="true" />
-            <span>{filter === 'attachments' ? '附件' : listMode === 'threads' ? '会话' : '更多'}</span>
-            <ChevronDown size={13} aria-hidden="true" />
-          </button>
-          {listModeMenu && (
-            <ContextMenu
-              x={listModeMenu.x}
-              y={listModeMenu.y}
-              items={listModeMenuItems}
-              onClose={() => setListModeMenu(null)}
-              closeIgnoreRef={listModeMenuTriggerRef}
-              className="mobile-inbox-filter-menu-surface"
-              ariaLabel="邮件筛选和列表模式"
-            />
-          )}
-        </div>
-      </div>
+      {filterMenu && (
+        <ContextMenu
+          x={filterMenu.x}
+          y={filterMenu.y}
+          items={filterMenuItems}
+          onClose={() => setFilterMenu(null)}
+          closeIgnoreRef={filterMenuTriggerRef}
+          className="mobile-inbox-filter-menu-surface"
+          ariaLabel="邮件筛选和列表模式"
+        />
+      )}
     </header>
   );
 }

--- a/src/components/mobile/MobileSettingsRoot.test.tsx
+++ b/src/components/mobile/MobileSettingsRoot.test.tsx
@@ -54,7 +54,7 @@ describe('MobileSettingsRoot', () => {
       />,
     );
 
-    expect(screen.getByRole('button', { name: '打开账号设置' })).toBeEnabled();
+    expect(screen.getByRole<HTMLButtonElement>('button', { name: '打开账号设置' }).disabled).toBe(false);
     const disabledRows = Array.from(document.querySelectorAll<HTMLButtonElement>('.mobile-settings-row:disabled'));
     expect(disabledRows.length).toBeGreaterThan(0);
   });

--- a/src/components/mobileFinalPolishContract.test.mjs
+++ b/src/components/mobileFinalPolishContract.test.mjs
@@ -1,0 +1,39 @@
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '..', '..');
+const read = (relative) => readFileSync(join(repoRoot, relative), 'utf8');
+const entryCss = read('src/ui-2026.css');
+const finalCss = read('src/styles/deai-final-polish.css');
+const inboxHeader = read('src/components/mobile/MobileInboxHeader.tsx');
+const layoutTs = read('src/components/messageListLayout.ts');
+
+describe('final mobile polish contract', () => {
+  it('loads the final polish after the first product pass', () => {
+    const firstPass = entryCss.indexOf("@import './styles/deai-product-polish.css';");
+    const finalPass = entryCss.indexOf("@import './styles/deai-final-polish.css';");
+    expect(firstPass).toBeGreaterThanOrEqual(0);
+    expect(finalPass).toBeGreaterThan(firstPass);
+  });
+
+  it('uses one filter utility instead of a persistent mobile filter tab row', () => {
+    expect(inboxHeader).not.toContain('mobile-inbox-filter-row');
+    expect(inboxHeader).toContain('mobile-filter-trigger');
+    expect(inboxHeader).toContain('filterMenuItems');
+  });
+
+  it('keeps the mobile mail list dense without shrinking below a large touch row', () => {
+    expect(layoutTs).toMatch(/MOBILE_MESSAGE_ROW_HEIGHT\s*=\s*76/);
+    expect(finalCss).toMatch(/\.mobile-message-list-panel \.message-leading\s*\{[\s\S]*?display:\s*none;/);
+  });
+
+  it('reduces reader, settings and composer feature-showcase chrome', () => {
+    expect(finalCss).toMatch(/\.reader-actions :is\(button, summary\) > span\s*\{[\s\S]*?clip-path:\s*inset\(50%\)/);
+    expect(finalCss).toMatch(/\.mobile-settings-row-icon\s*\{[\s\S]*?display:\s*none;/);
+    expect(finalCss).toContain('button[aria-label="收起写信"]');
+    expect(finalCss).not.toContain('linear-gradient');
+    expect(finalCss).not.toContain('backdrop-filter');
+  });
+});

--- a/src/styles/deai-final-polish.css
+++ b/src/styles/deai-final-polish.css
@@ -1,0 +1,380 @@
+/*
+ * Final product polish: remove the last "designed demo" signals.
+ * Mobile keeps native-sized hit targets while reducing persistent chrome,
+ * decorative surfaces, oversized spacing and feature-showcase labels.
+ */
+
+@media (max-width: 720px) {
+  /* Inbox: one compact header. Filtering is a utility, not a permanent tab bar. */
+  .app-shell.is-mobile-app .mobile-inbox-header {
+    padding: max(4px, env(safe-area-inset-top)) 8px 0;
+  }
+
+  .app-shell.is-mobile-app .mobile-inbox-title-row {
+    min-height: 50px;
+  }
+
+  .app-shell.is-mobile-app .mobile-inbox-title {
+    gap: 5px;
+    padding-inline: 2px;
+  }
+
+  .app-shell.is-mobile-app .mobile-inbox-title-copy {
+    min-width: 0;
+    flex: 1 1 auto;
+    display: grid;
+    gap: 0;
+  }
+
+  .app-shell.is-mobile-app .mobile-inbox-title-copy strong {
+    overflow: hidden;
+    color: var(--ui-text);
+    font-size: 17.5px;
+    font-weight: 600;
+    line-height: 1.22;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .app-shell.is-mobile-app .mobile-inbox-title-copy small {
+    overflow: hidden;
+    color: var(--ui-text-tertiary);
+    font-size: 11.5px;
+    font-weight: 400;
+    line-height: 1.25;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .app-shell.is-mobile-app .mobile-inbox-actions {
+    gap: 0;
+  }
+
+  .app-shell.is-mobile-app .mobile-filter-trigger {
+    position: relative;
+  }
+
+  .app-shell.is-mobile-app .mobile-filter-trigger.active {
+    color: var(--ui-accent);
+    background: transparent;
+  }
+
+  .app-shell.is-mobile-app .mobile-filter-trigger.active::after {
+    position: absolute;
+    right: 7px;
+    top: 8px;
+    width: 4px;
+    height: 4px;
+    border-radius: 50%;
+    background: var(--ui-accent);
+    content: "";
+  }
+
+  .app-shell.is-mobile-app .mobile-inbox-filter-row {
+    display: none;
+  }
+
+  /* The mobile list should feel like Mail, not a contact-card feed. */
+  .app-shell.is-mobile-app .mobile-message-list-panel .message-card {
+    min-height: 0;
+    padding: 7px 50px 7px 16px;
+  }
+
+  .app-shell.is-mobile-app .mobile-message-list-panel .message-leading {
+    display: none;
+  }
+
+  .app-shell.is-mobile-app .mobile-message-list-panel .message-unread-dot {
+    left: 6px;
+    top: 13px;
+    width: 4px;
+    height: 4px;
+    border: 0;
+    box-shadow: none;
+  }
+
+  .app-shell.is-mobile-app .mobile-message-list-panel .message-topline {
+    min-height: 17px;
+    margin-bottom: 1px;
+  }
+
+  .app-shell.is-mobile-app .mobile-message-list-panel :is(.sender, .thread-sender) {
+    font-size: 14.5px;
+    line-height: 1.2;
+  }
+
+  .app-shell.is-mobile-app .mobile-message-list-panel :is(.subject, .thread-subject) {
+    font-size: 14px;
+    line-height: 1.24;
+  }
+
+  .app-shell.is-mobile-app .mobile-message-list-panel :is(.message-card p, .thread-preview) {
+    font-size: 12.5px;
+    line-height: 1.28;
+  }
+
+  .app-shell.is-mobile-app .mobile-message-list-panel :is(.message-card time, .thread-card time) {
+    font-size: 11.5px;
+  }
+
+  .app-shell.is-mobile-app .message-mobile-menu-button {
+    right: 2px;
+    color: var(--ui-text-tertiary);
+  }
+
+  /* Compose stays reachable but stops looking like a promotional CTA. */
+  .app-shell.is-mobile-app .mobile-bottom-nav > .mobile-bottom-compose {
+    right: 14px;
+    bottom: calc(14px + env(safe-area-inset-bottom));
+    width: 50px;
+    min-width: 50px;
+    height: 50px;
+    min-height: 50px;
+    border: 0;
+    border-radius: 50%;
+    box-shadow: 0 2px 9px color-mix(in srgb, var(--ui-text) 14%, transparent);
+  }
+
+  .app-shell.is-mobile-app .mobile-bottom-compose-icon svg {
+    width: 20px;
+    height: 20px;
+  }
+
+  .app-shell.is-mobile-app .mobile-message-list-panel :is(.message-list, .thread-list) {
+    padding-bottom: calc(70px + env(safe-area-inset-bottom));
+  }
+
+  /* Drawer: quieter selection and less floating-panel theatre. */
+  .app-shell.is-mobile-app .mobile-mailbox-sheet {
+    box-shadow: 5px 0 18px color-mix(in srgb, var(--ui-text) 8%, transparent);
+  }
+
+  .app-shell.is-mobile-app .mobile-mailbox-row {
+    min-height: 46px;
+    padding-block: 6px;
+  }
+
+  .app-shell.is-mobile-app .mobile-mailbox-row.active {
+    color: var(--ui-text);
+    background: var(--quiet-row-selected);
+  }
+
+  .app-shell.is-mobile-app .mobile-mailbox-row.active .mobile-mailbox-row-icon,
+  .app-shell.is-mobile-app .mobile-mailbox-row.active .mobile-mailbox-count,
+  .app-shell.is-mobile-app .mobile-mailbox-check {
+    color: var(--ui-accent);
+  }
+
+  /* Reader: icon-first mail toolbar, content first. Text remains in the DOM. */
+  .app-shell.is-mobile-app .narrow-reader-navigation {
+    min-height: 48px;
+    padding: max(2px, env(safe-area-inset-top)) 8px 2px;
+  }
+
+  .app-shell.is-mobile-app .narrow-reader-navigation button {
+    width: 44px;
+    min-width: 44px;
+    padding: 0;
+    overflow: hidden;
+    font-size: 0;
+  }
+
+  .app-shell.is-mobile-app .narrow-reader-navigation button svg {
+    width: 20px;
+    height: 20px;
+  }
+
+  .app-shell.is-mobile-app .reader {
+    padding: 12px 16px calc(30px + env(safe-area-inset-bottom));
+  }
+
+  .app-shell.is-mobile-app .reader-header {
+    gap: 8px;
+    margin-bottom: 14px;
+  }
+
+  .app-shell.is-mobile-app .reader-header h1 {
+    margin-bottom: 7px;
+    font-size: 21px;
+    line-height: 1.27;
+  }
+
+  .app-shell.is-mobile-app .reader-actions {
+    gap: 1px;
+    padding: 3px 10px;
+    overflow-x: auto;
+    border-top: 1px solid var(--ui-border);
+    border-bottom: 0;
+  }
+
+  .app-shell.is-mobile-app .reader-actions :is(
+    button,
+    .reader-more-menu summary,
+    .reader-reply-menu summary,
+    .reader-ai-trigger,
+    select
+  ) {
+    min-width: 44px;
+    min-height: 44px;
+    height: 44px;
+    padding-inline: 8px;
+    border-radius: 6px;
+  }
+
+  .app-shell.is-mobile-app .reader-actions .primary-action {
+    min-width: 44px;
+    background: transparent;
+  }
+
+  .app-shell.is-mobile-app .reader-actions :is(button, summary) > span {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    overflow: hidden;
+    clip: rect(0 0 0 0);
+    clip-path: inset(50%);
+    white-space: nowrap;
+  }
+
+  .app-shell.is-mobile-app .reader-message-actions {
+    margin-inline-start: 0;
+    padding-inline-start: 0;
+  }
+
+  .app-shell.is-mobile-app .reader-meta {
+    gap: 6px;
+    font-size: 11.5px;
+  }
+
+  .app-shell.is-mobile-app :is(.reader-html, .body-text, .reader-plain-text) {
+    line-height: 1.66;
+  }
+
+  /* Settings: typography + rows carry hierarchy; icons do not need decoration. */
+  .app-shell.is-mobile-app .mobile-settings-account-summary {
+    min-height: 64px;
+    margin-bottom: 16px;
+    padding-block: 8px;
+  }
+
+  .app-shell.is-mobile-app .mobile-settings-account-avatar {
+    width: 34px;
+    min-width: 34px;
+    height: 34px;
+    font-size: 13px;
+  }
+
+  .app-shell.is-mobile-app .mobile-settings-group {
+    margin-bottom: 18px;
+  }
+
+  .app-shell.is-mobile-app .mobile-settings-group h2 {
+    padding-bottom: 5px;
+    font-size: 11.5px;
+  }
+
+  .app-shell.is-mobile-app .mobile-settings-row {
+    min-height: 52px;
+    gap: 0;
+    padding-block: 6px;
+  }
+
+  .app-shell.is-mobile-app .mobile-settings-row-icon {
+    display: none;
+  }
+
+  .app-shell.is-mobile-app .mobile-settings-row-copy strong {
+    font-weight: 400;
+  }
+
+  .settings-workspace .settings-shell.settings-modal .settings-page-heading :is(h2, p) {
+    display: none;
+  }
+
+  .settings-workspace .settings-shell.settings-modal .settings-page-header {
+    padding: 4px 16px 2px;
+  }
+
+  .settings-workspace .settings-shell.settings-modal .settings-page-header:not(:has(.settings-account-context)) {
+    display: none;
+  }
+
+  .settings-workspace .settings-shell.settings-modal .settings-account-context {
+    color: var(--st-text-tertiary);
+    font-size: 11.5px;
+    font-weight: 400;
+  }
+
+  .settings-workspace .settings-shell.settings-modal .settings-page-content {
+    gap: 14px;
+    padding-top: 8px;
+  }
+
+  /* Composer: mail editor controls, not a feature showcase ribbon. */
+  .app-shell.is-mobile-app .composer .composer-editor-header {
+    min-height: calc(50px + env(safe-area-inset-top));
+  }
+
+  .app-shell.is-mobile-app .composer-header-actions > button[aria-label="收起写信"] {
+    display: none;
+  }
+
+  .app-shell.is-mobile-app .composer .composer-field-row {
+    min-height: 46px;
+    grid-template-columns: 44px minmax(0, 1fr);
+  }
+
+  .app-shell.is-mobile-app .composer .composer-quick-toolbar {
+    min-height: 44px;
+  }
+
+  .app-shell.is-mobile-app .composer .composer-footer-tool-group {
+    gap: 0;
+  }
+
+  .app-shell.is-mobile-app .composer .composer-footer-tool-group > button {
+    width: 44px;
+    min-width: 44px;
+    min-height: 44px;
+    padding: 0;
+    font-size: 0;
+    border-radius: 6px;
+    background: transparent;
+  }
+
+  .app-shell.is-mobile-app .composer .composer-footer-tool-group > button small {
+    position: absolute;
+    min-width: 14px;
+    padding-inline: 3px;
+    font-size: 10px;
+  }
+
+  .app-shell.is-mobile-app .composer .composer-format-glyph,
+  .app-shell.is-mobile-app .composer .composer-more-glyph {
+    font-size: 16px;
+  }
+
+  .app-shell.is-mobile-app .composer .composer-footer-main {
+    gap: 3px;
+  }
+
+  .app-shell.is-mobile-app .composer .composer-send-primary {
+    min-width: 70px;
+    padding-inline: 13px;
+  }
+
+  .app-shell.is-mobile-app .composer .composer-send-primary .composer-send-label-full {
+    display: none;
+  }
+
+  .app-shell.is-mobile-app .composer .composer-send-label-compact {
+    display: inline;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .app-shell.is-mobile-app .mobile-bottom-compose:active {
+    transform: none;
+  }
+}

--- a/src/ui-2026.css
+++ b/src/ui-2026.css
@@ -34,5 +34,6 @@
 /* Compatibility and component layers */
 @import './components/notifications.css';
 
-/* Product-level hierarchy and mobile de-AI pass. This intentionally loads last. */
+/* Product hierarchy layers. */
 @import './styles/deai-product-polish.css';
+@import './styles/deai-final-polish.css';


### PR DESCRIPTION
Final mobile UI/UX polish pass:
- collapse persistent inbox filter tabs into one utility menu
- tighten mobile virtual mail rows from 88px to 76px
- reduce avatar/card-feed feel in the inbox
- make reader actions icon-first while retaining accessible labels
- simplify settings hierarchy and duplicate page chrome
- reduce composer feature-ribbon styling
- fix the previous Vitest assertion incompatibility
- add final polish regression contract