### PR TITLE
Final UI polish and release-safe publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -117,7 +117,9 @@ jobs:
   build:
     name: Build installers (${{ matrix.platform }})
     needs: validate
-    if: startsWith(github.ref, 'refs/tags/') || (github.event_name == 'workflow_dispatch')
+    # Tags/workflow_dispatch remain supported. A main push is release-capable
+    # only when the dedicated release commit uses the exact release: v prefix.
+    if: startsWith(github.ref, 'refs/tags/') || github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && github.ref == 'refs/heads/main' && startsWith(github.event.head_commit.message, 'release: v'))
     strategy:
       fail-fast: false
       matrix:
@@ -183,7 +185,7 @@ jobs:
   build-android:
     name: Build Android (APK and AAB)
     needs: validate
-    if: startsWith(github.ref, 'refs/tags/') || (github.event_name == 'workflow_dispatch')
+    if: startsWith(github.ref, 'refs/tags/') || github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && github.ref == 'refs/heads/main' && startsWith(github.event.head_commit.message, 'release: v'))
     runs-on: ubuntu-22.04
     timeout-minutes: 45
     steps:
@@ -316,9 +318,18 @@ jobs:
 
       - name: Resolve release metadata
         id: meta
+        shell: bash
         run: |
-          echo "version=$(node -p "require('./package.json').version")" >> "$GITHUB_OUTPUT"
-          echo "tag=${{ github.event_name == 'workflow_dispatch' && github.event.inputs.tag || github.ref_name }}" >> "$GITHUB_OUTPUT"
+          VERSION="$(node -p "require('./package.json').version")"
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            TAG="${{ github.event.inputs.tag }}"
+          elif [[ "$GITHUB_REF" == refs/tags/* ]]; then
+            TAG="$GITHUB_REF_NAME"
+          else
+            TAG="v${VERSION}"
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
           echo "repo=${{ github.repository }}" >> "$GITHUB_OUTPUT"
 
       - name: Generate updater manifest (latest.json)
@@ -364,7 +375,7 @@ jobs:
           if gh release view "$TAG" --json tagName >/dev/null 2>&1; then
             gh release edit "$TAG" --title "Better Email $TAG" --notes "$BODY"
           else
-            gh release create "$TAG" --title "Better Email $TAG" --notes "$BODY"
+            gh release create "$TAG" --target "$GITHUB_SHA" --title "Better Email $TAG" --notes "$BODY"
           fi
           gh release upload "$TAG" \
             "dist/installers-macos-latest/Better_Email_${VERSION}_mac_arm.dmg" \

--- a/src/components/AppTitlebar.tsx
+++ b/src/components/AppTitlebar.tsx
@@ -119,8 +119,6 @@ export default function AppTitlebar({
   onSearchScopeChange,
   onClearSearchAndFilter,
   onApplySearchShortcut,
-  currentViewLabel,
-  viewSummary,
   isRefreshing = false,
   refreshNotice = null,
   onRefresh,
@@ -210,28 +208,9 @@ export default function AppTitlebar({
       role="banner"
     >
       <div className="app-titlebar-grid">
-        <div className="titlebar-left">
+        <div className="titlebar-left" aria-hidden="true">
           {isNativeTitlebar && (
             <TitlebarDragRegion platform={platform} onToggleMaximize={() => { void toggleMaximize(); }} className="titlebar-left-drag" />
-          )}
-          <div className="titlebar-brand">
-            <img
-              src="/brand/v4/brand-mark-64.png"
-              alt=""
-              width={22}
-              height={22}
-              draggable={false}
-            />
-            <span>Better Email</span>
-          </div>
-          {currentViewLabel && (
-            <div
-              className="titlebar-context"
-              title={viewSummary ? `${currentViewLabel} · ${viewSummary}` : currentViewLabel}
-            >
-              <span className="titlebar-context-label">{currentViewLabel}</span>
-              {viewSummary && <span className="titlebar-context-count">{viewSummary}</span>}
-            </div>
           )}
         </div>
 

--- a/src/components/WindowChrome.test.tsx
+++ b/src/components/WindowChrome.test.tsx
@@ -72,14 +72,15 @@ describe('AppTitlebar', () => {
     expect(detectDesktopPlatform()).toBe('web');
   });
 
-  it('keeps the current view and result count together beside search', () => {
+  it('keeps mailbox identity out of the window-level titlebar', () => {
     const { container } = renderTitlebar(undefined, '统一收件箱', '40+ 封');
-    const context = container.querySelector('.titlebar-context');
 
-    expect(context).not.toBeNull();
-    expect(context?.querySelector('.titlebar-context-label')?.textContent).toBe('统一收件箱');
-    expect(context?.querySelector('.titlebar-context-count')?.textContent).toBe('40+ 封');
-    expect(context?.parentElement?.classList.contains('titlebar-left')).toBe(true);
+    expect(container.querySelector('.titlebar-brand')).toBeNull();
+    expect(container.querySelector('.titlebar-context')).toBeNull();
+    expect(screen.queryByText('Better Email')).toBeNull();
+    expect(screen.queryByText('统一收件箱')).toBeNull();
+    expect(screen.queryByText('40+ 封')).toBeNull();
+    expect(container.querySelector('.titlebar-center')).not.toBeNull();
   });
 
   it('renders a browser preview without native window controls or fake traffic lights', () => {


### PR DESCRIPTION
Final release-level polish for Better Email v1.0.51.

- Simplify desktop titlebar to window-level chrome only: search, refresh/sync and native window controls.
- Remove duplicated brand/mailbox/count context from titlebar and lock the behavior with a regression test.
- Allow an explicit `release: vX.Y.Z` commit on `main` to run signed desktop + Android builds and publish the GitHub Release, while ordinary main pushes remain non-publishing.
- Keep existing tag and workflow_dispatch release paths compatible.