### PR TITLE
feat:修复独立写信窗口拖动与macOS红黄绿避让

### DIFF
--- a/scripts/ui-smoke.mjs
+++ b/scripts/ui-smoke.mjs
@@ -3208,6 +3208,60 @@ async function main() {
     }
     await captureScreenshot(cdp, 'settings-standalone-window-1040');
 
+    await setUiViewport(cdp, 960, 700);
+    await evalInPage(
+      cdp,
+      `location.href = ${JSON.stringify(`${url}/?window=compose`)}`,
+    );
+    await waitForExpression(cdp, "document.querySelector('.standalone-composer-app .composer-backdrop.is-native-window')", 45_000);
+    await waitForExpression(cdp, "['web', 'macos', 'windows', 'linux'].includes(document.body.dataset.composerWindowPlatform)");
+    await evalInPage(cdp, "document.body.dataset.composerWindowPlatform = 'macos'");
+    await waitForExpression(cdp, "document.body.dataset.composerWindowPlatform === 'macos'");
+    const standaloneComposerMacSnapshot = await evalInPage(cdp, `(() => {
+      const header = document.querySelector('.composer-editor-header');
+      const title = document.querySelector('.composer-editor-header .composer-title-copy strong');
+      const dragRegion = document.querySelector('.composer-titlebar-drag-region[data-tauri-drag-region]');
+      const headerRect = header?.getBoundingClientRect();
+      const titleRect = title?.getBoundingClientRect();
+      const dragRect = dragRegion?.getBoundingClientRect();
+      return {
+        hasMailChrome: Boolean(document.querySelector('.app-titlebar, .app-shell > .sidebar, .message-list-panel, .reader-panel, .standalone-window-chrome')),
+        hasDuplicateClose: Boolean(document.querySelector('.composer-editor-header [aria-label="关闭写信窗口"], .composer-editor-header [aria-label="收起写信"]')),
+        macTrafficLightsSafe: Boolean(titleRect) && titleRect.left >= 84,
+        dragRegionFillsHeader: Boolean(dragRect && headerRect)
+          && Math.abs(dragRect.left - headerRect.left) <= 1
+          && Math.abs(dragRect.right - headerRect.right) <= 1
+          && Math.abs(dragRect.height - headerRect.height) <= 1,
+        noHorizontalScroll: document.documentElement.scrollWidth <= window.innerWidth + 1
+          && document.body.scrollWidth <= window.innerWidth + 1,
+      };
+    })()`);
+    console.log(`[ui-smoke] standalone-composer macOS geometry ${JSON.stringify(standaloneComposerMacSnapshot)}`);
+    if (
+      standaloneComposerMacSnapshot.hasMailChrome
+      || standaloneComposerMacSnapshot.hasDuplicateClose
+      || !standaloneComposerMacSnapshot.macTrafficLightsSafe
+      || !standaloneComposerMacSnapshot.dragRegionFillsHeader
+      || !standaloneComposerMacSnapshot.noHorizontalScroll
+    ) {
+      throw new Error(`Standalone composer macOS geometry contract failed: ${JSON.stringify(standaloneComposerMacSnapshot)}`);
+    }
+
+    await evalInPage(cdp, "document.body.dataset.composerWindowPlatform = 'windows'");
+    await waitForExpression(cdp, "document.body.dataset.composerWindowPlatform === 'windows'");
+    const standaloneComposerWinSnapshot = await evalInPage(cdp, `(() => {
+      const title = document.querySelector('.composer-editor-header .composer-title-copy strong');
+      const titleRect = title?.getBoundingClientRect();
+      return {
+        windowsNormalPadding: Boolean(titleRect) && titleRect.left < 50,
+      };
+    })()`);
+    console.log(`[ui-smoke] standalone-composer Windows geometry ${JSON.stringify(standaloneComposerWinSnapshot)}`);
+    if (!standaloneComposerWinSnapshot.windowsNormalPadding) {
+      throw new Error(`Standalone composer Windows geometry contract failed: ${JSON.stringify(standaloneComposerWinSnapshot)}`);
+    }
+    await captureScreenshot(cdp, 'composer-standalone-window-960');
+
     if (checks.some((ok) => !ok)) throw new Error(`UI smoke checks failed: ${JSON.stringify(checks)}`);
 
     const report = {
@@ -3276,6 +3330,8 @@ async function main() {
         'settings application surface opens',
         'standalone settings renderer fills its native window without mail chrome',
         'standalone settings uses a unified transparent macOS titlebar with safe traffic-light spacing',
+        'standalone composer renderer fills its native window without mail chrome',
+        'standalone composer uses safe traffic-light clearance on macOS and native padding on Windows',
         'settings navigation renders one page at a time',
         'settings desktop sidebar switches standalone pages',
         'settings narrow layout uses native root and detail navigation',

--- a/src/components/ComposerWindow.test.tsx
+++ b/src/components/ComposerWindow.test.tsx
@@ -304,4 +304,18 @@ describe('ComposerWindow focus lifecycle', () => {
     expect(screen.getByRole('dialog', { name: '选择定时发送时间' })).not.toBeNull();
     expect(document.querySelector('.composer-schedule-status')).toBeNull();
   });
+
+  it('configures standalone window chrome with titlebar drag region and platform attributes', () => {
+    const { container, rerender } = render(cloneElement(composer(), { standaloneWindow: true, platform: 'macos' }));
+
+    const dragRegion = container.querySelector('.composer-titlebar-drag-region');
+    expect(dragRegion).not.toBeNull();
+    expect(dragRegion?.hasAttribute('data-tauri-drag-region')).toBe(true);
+    expect(container.querySelector('.composer-backdrop')?.getAttribute('data-composer-platform')).toBe('macos');
+    expect(screen.queryByRole('button', { name: '收起写信' })).toBeNull();
+    expect(screen.queryByRole('button', { name: '关闭写信窗口' })).toBeNull();
+
+    rerender(cloneElement(composer(), { standaloneWindow: true, platform: 'windows' }));
+    expect(container.querySelector('.composer-backdrop')?.getAttribute('data-composer-platform')).toBe('windows');
+  });
 });

--- a/src/components/ComposerWindow.tsx
+++ b/src/components/ComposerWindow.tsx
@@ -86,6 +86,7 @@ function clampComposerPosition(
 export type ComposerWindowProps = {
   minimized: boolean;
   standaloneWindow?: boolean;
+  platform?: 'macos' | 'windows' | 'linux' | 'web';
   focusRequest?: number;
   draft: DraftInput;
   accounts: Account[];
@@ -134,6 +135,7 @@ export type ComposerWindowProps = {
 export default function ComposerWindow({
   minimized,
   standaloneWindow = false,
+  platform = 'web',
   focusRequest = 0,
   draft,
   accounts,
@@ -467,10 +469,21 @@ export default function ComposerWindow({
     else onSendDraft();
   }
 
+  const resolvedPlatform = (
+    platform !== 'web'
+      ? platform
+      : typeof document !== 'undefined' && document.body.dataset.composerWindowPlatform === 'macos'
+        ? 'macos'
+        : typeof document !== 'undefined' && document.body.dataset.composerWindowPlatform === 'windows'
+          ? 'windows'
+          : platform
+  );
+
   return (
     <div
       ref={backdropRef}
       className={`composer-backdrop ${standaloneWindow ? 'is-native-window' : isMobileComposerViewport ? 'is-modal' : 'is-floating'}`}
+      data-composer-platform={standaloneWindow ? resolvedPlatform : undefined}
       role="dialog"
       aria-modal={!standaloneWindow && isMobileComposerViewport ? 'true' : undefined}
       aria-label="写信窗口"
@@ -493,6 +506,13 @@ export default function ComposerWindow({
         <div className={`composer-workspace${contactsPanelVisible ? ' has-contacts' : ''}`}>
           <div className="composer-editor-pane">
             <header className="composer-editor-header" onPointerDown={standaloneWindow ? undefined : beginDrag}>
+              {standaloneWindow && (
+                <div
+                  className="composer-titlebar-drag-region"
+                  data-tauri-drag-region
+                  aria-hidden="true"
+                />
+              )}
               <span className="composer-title-copy">
                 <strong>{windowHeading}</strong>
                 <span

--- a/src/components/StandaloneComposerApp.tsx
+++ b/src/components/StandaloneComposerApp.tsx
@@ -72,6 +72,8 @@ export default function StandaloneComposerApp() {
   const [composerSendProgress, setComposerSendProgress] = useState<number | null>(null);
   const [composerSendProgressMessage, setComposerSendProgressMessage] = useState<string | null>(null);
   const [composerAttachmentProgress, setComposerAttachmentProgress] = useState<number | null>(null);
+  const [platform, setPlatform] = useState<'macos' | 'windows' | 'linux' | 'web'>('web');
+  const platformReadyRef = useRef(false);
   const closingRef = useRef(false);
   const bootedRef = useRef(false);
   const frontendReadyRef = useRef(false);
@@ -87,6 +89,31 @@ export default function StandaloneComposerApp() {
   const frontendReady = nativeCloseListenerReady && (booted || loadError !== null);
   frontendReadyRef.current = frontendReady;
   loadErrorRef.current = loadError;
+
+  useEffect(() => {
+    let active = true;
+    const body = document.body;
+
+    void invoke<string>(IPC.GetPlatform)
+      .catch(() => 'web')
+      .then((detectedPlatform) => {
+        if (!active) return;
+        const resolved = (
+          detectedPlatform === 'macos' || detectedPlatform === 'windows' || detectedPlatform === 'linux'
+            ? detectedPlatform
+            : 'web'
+        );
+        body.dataset.composerWindowPlatform = resolved;
+        setPlatform(resolved);
+        platformReadyRef.current = true;
+      });
+
+    return () => {
+      active = false;
+      platformReadyRef.current = false;
+      delete body.dataset.composerWindowPlatform;
+    };
+  }, []);
 
   const loadComposerData = useCallback(async (preferredAccountId?: number) => {
     const nextAccounts = await invoke<Account[]>(IPC.ListAccounts);
@@ -335,10 +362,19 @@ export default function StandaloneComposerApp() {
     let active = true;
     const boot = async () => {
       try {
-        // Preload stable composer data first. Consume the pending request only
-        // after the standalone app is nearly ready, so a click during prewarm
-        // cannot be taken too early and then lose its wake-up event.
-        await loadComposerData();
+        const [nextPlatform] = await Promise.all([
+          invoke<string>(IPC.GetPlatform).catch(() => 'web'),
+          loadComposerData(),
+        ]);
+        if (!active) return;
+        const resolved = (
+          nextPlatform === 'macos' || nextPlatform === 'windows' || nextPlatform === 'linux'
+            ? nextPlatform
+            : 'web'
+        );
+        document.body.dataset.composerWindowPlatform = resolved;
+        setPlatform(resolved);
+        platformReadyRef.current = true;
         if (!active) return;
         const pending = normalizeComposerRequest(await takePendingComposerRequest());
         if (!active) return;
@@ -486,6 +522,7 @@ export default function StandaloneComposerApp() {
       {isComposerOpen ? (
         <ComposerWindow
           standaloneWindow
+          platform={platform}
           minimized={isComposerMinimized}
           focusRequest={composerFocusRequest}
           draft={draft}

--- a/src/components/composer/composer-polish.css
+++ b/src/components/composer/composer-polish.css
@@ -229,3 +229,36 @@
     flex-basis: 168px;
   }
 }
+
+/* Standalone native composer window: titlebar drag region and platform chrome */
+.composer-backdrop.is-native-window .composer-editor-header {
+  position: relative;
+  cursor: default;
+}
+
+.composer-titlebar-drag-region {
+  position: absolute;
+  inset: 0;
+  z-index: 1;
+  user-select: none;
+  -webkit-user-select: none;
+}
+
+.composer-backdrop.is-native-window .composer-editor-header > :not(.composer-titlebar-drag-region) {
+  position: relative;
+  z-index: 2;
+}
+
+.composer-backdrop.is-native-window .composer-title-copy {
+  pointer-events: none;
+}
+
+/* macOS native window overlay titlebar safety clearance for traffic lights */
+body[data-composer-window-platform='macos']
+  .composer-backdrop.is-native-window
+  .composer-editor-header,
+.composer-backdrop.is-native-window[data-composer-platform='macos']
+  .composer-editor-header {
+  padding-left: 88px;
+}
+

--- a/src/components/composer/composer-polish.css
+++ b/src/components/composer/composer-polish.css
@@ -261,4 +261,3 @@ body[data-composer-window-platform='macos']
   .composer-editor-header {
   padding-left: 88px;
 }
-

--- a/src/components/standaloneWindowChromeContract.test.mjs
+++ b/src/components/standaloneWindowChromeContract.test.mjs
@@ -6,24 +6,57 @@ import { describe, expect, it } from 'vitest';
 const root = join(dirname(fileURLToPath(import.meta.url)), '..', '..');
 const bridge = readFileSync(join(root, 'src/tauriBridge.prod.ts'), 'utf8');
 const appRoot = readFileSync(join(root, 'src/app/AppRoot.tsx'), 'utf8');
-const chrome = readFileSync(join(root, 'src/components/DesktopWindowChrome.tsx'), 'utf8');
+const composerSource = readFileSync(join(root, 'src/components/ComposerWindow.tsx'), 'utf8');
+const composerAppSource = readFileSync(join(root, 'src/components/StandaloneComposerApp.tsx'), 'utf8');
+const settingsSource = readFileSync(join(root, 'src/components/settings/SettingsFrame.tsx'), 'utf8');
+const settingsAppSource = readFileSync(join(root, 'src/components/StandaloneSettingsApp.tsx'), 'utf8');
+const composerCss = readFileSync(join(root, 'src/components/composer/composer-polish.css'), 'utf8');
+const settingsCss = readFileSync(join(root, 'src/components/settings/settings-shell.css'), 'utf8');
 
-describe('standalone desktop window chrome', () => {
-  it('uses overlay native titlebars for composer and settings', () => {
-    expect(bridge).not.toMatch(/titleBarStyle:\s*'visible'/);
-    expect(bridge.match(/titleBarStyle:\s*'overlay'/g)?.length ?? 0).toBeGreaterThanOrEqual(2);
-    expect(bridge.match(/hiddenTitle:\s*true/g)?.length ?? 0).toBeGreaterThanOrEqual(2);
-  });
-
-  it('keeps both standalone surfaces on their existing content roots', () => {
+describe('standalone desktop window chrome contract', () => {
+  it('keeps both standalone surfaces on their existing content roots with no duplicate chrome', () => {
     expect(appRoot).not.toContain("import StandaloneWindowFrame from '../components/StandaloneWindowFrame'");
     expect(appRoot).not.toContain('<StandaloneWindowFrame');
     expect(appRoot).toContain('? <StandaloneComposerApp />');
     expect(appRoot).toContain('? <StandaloneSettingsApp />');
   });
 
-  it('removes decorations from the current Windows child window', () => {
-    expect(chrome).toContain("resolved === 'windows'");
-    expect(chrome).toContain('setDecorations(false)');
+  it('provides safe titlebar drag regions for standalone composer and settings windows', () => {
+    expect(composerSource).toContain('className="composer-titlebar-drag-region"');
+    expect(composerSource).toContain('data-tauri-drag-region');
+    expect(settingsSource).toContain('className="settings-titlebar-drag-region"');
+    expect(settingsSource).toContain('data-tauri-drag-region');
+
+    expect(composerCss).toContain('.composer-titlebar-drag-region');
+    expect(composerCss).toContain('pointer-events: none');
+    expect(settingsCss).toContain('.settings-titlebar-drag-region');
+    expect(settingsCss).toContain('pointer-events: none');
+  });
+
+  it('configures native overlay titlebars and safe traffic-light clearance on macOS', () => {
+    expect(bridge).not.toMatch(/titleBarStyle:\s*'visible'/);
+    expect(bridge.match(/titleBarStyle:\s*'overlay'/g)?.length ?? 0).toBeGreaterThanOrEqual(2);
+    expect(bridge.match(/hiddenTitle:\s*true/g)?.length ?? 0).toBeGreaterThanOrEqual(2);
+    expect(bridge.match(/trafficLightPosition:\s*new LogicalPosition\(16,\s*18\)/g)?.length ?? 0).toBeGreaterThanOrEqual(2);
+
+    expect(composerCss).toContain("body[data-composer-window-platform='macos']");
+    expect(composerCss).toContain('padding-left: 88px');
+    expect(settingsCss).toContain("body[data-settings-window-platform='macos']");
+    expect(settingsCss).toContain('padding-left: 88px');
+  });
+
+  it('preserves native window controls on Windows without macOS styling', () => {
+    expect(bridge.match(/decorations:\s*true/g)?.length ?? 0).toBeGreaterThanOrEqual(2);
+    expect(composerAppSource).not.toContain('setDecorations(false)');
+    expect(settingsAppSource).not.toContain('setDecorations(false)');
+    expect(composerCss).not.toContain("body[data-composer-window-platform='windows']");
+    expect(settingsCss).not.toContain("body[data-settings-window-platform='windows']");
+  });
+
+  it('resolves platform from native backend without user-agent guessing', () => {
+    expect(composerAppSource).toContain('IPC.GetPlatform');
+    expect(composerAppSource).not.toContain('navigator.userAgent');
+    expect(settingsAppSource).toContain('IPC.GetPlatform');
+    expect(settingsAppSource).not.toContain('navigator.userAgent');
   });
 });

--- a/src/styles/standalone-window-chrome.css
+++ b/src/styles/standalone-window-chrome.css
@@ -95,6 +95,16 @@
   flex: 1 1 auto;
 }
 
+body[data-composer-window-platform='macos']
+  .standalone-composer-app
+  .composer-backdrop.is-native-window
+  .composer-editor-header,
+.standalone-composer-app
+  .composer-backdrop.is-native-window[data-composer-platform='macos']
+  .composer-editor-header {
+  padding-left: 88px;
+}
+
 .app-shell.standalone-settings-window {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
### 变更摘要

1. **独立写信窗口拖动支持**：在 `ComposerWindow` 标题栏空白区域和标题区增加 `composer-titlebar-drag-region` 并赋予 `data-tauri-drag-region`，使独立写信窗口可通过顶部安全空白区域与标题拖动。交互控件（按钮、输入框、下拉框、编辑区等）维持更高层级，不被拖动层拦截。
2. **macOS 红黄绿避让**：独立写信窗口从后端 IPC (`IPC.GetPlatform`) 解析真实平台（不猜 user-agent），macOS 下为写信窗口标题栏应用 `padding-left: 88px` 安全避让间距，彻底消除红黄绿按钮遮挡压住“新邮件”标题的问题；且不增加多余视觉顶部栏，保持原布局紧凑与安静。
3. **Windows 平台控制与原生样式**：Windows 下不应用 macOS 红黄绿避让样式，保持正常内边距；同时保留 `decorations: true` 原生窗口控制与可用拖动区域。
4. **设置独立窗口无回归**：保持设置页已有透明标题栏与拖动逻辑，测试全部通过。
5. **契约与冒烟测试**：
   - 更新 `standaloneWindowChromeContract.test.mjs`，覆盖 no duplicate chrome、drag region 与 macOS/Windows 跨平台分支契约。
   - `ComposerWindow.test.tsx` 增加独立窗口拖动区域与平台契约单测。
   - `ui-smoke.mjs` 增加独立写信窗口真实几何尺寸与 macOS/Windows 避让断言，全部通过。