### PR TITLE
feat:修复全局下拉弹窗变形与macOS点击Dock恢复窗口

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1071,11 +1071,19 @@ pub fn run() {
         .build(tauri::generate_context!())
         .expect("error while building Better Email")
         .run(move |_app_handle, event| {
-            if matches!(
-                event,
-                tauri::RunEvent::Exit | tauri::RunEvent::ExitRequested { .. }
-            ) {
-                exit_startup.shutdown();
+            match event {
+                #[cfg(desktop)]
+                tauri::RunEvent::Reopen { .. } => {
+                    if let Some(window) = _app_handle.get_webview_window("main") {
+                        let _ = window.show();
+                        let _ = window.unminimize();
+                        let _ = window.set_focus();
+                    }
+                }
+                tauri::RunEvent::Exit | tauri::RunEvent::ExitRequested { .. } => {
+                    exit_startup.shutdown();
+                }
+                _ => {}
             }
         });
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1072,7 +1072,7 @@ pub fn run() {
         .expect("error while building Better Email")
         .run(move |_app_handle, event| {
             match event {
-                #[cfg(desktop)]
+                #[cfg(target_os = "macos")]
                 tauri::RunEvent::Reopen { .. } => {
                     if let Some(window) = _app_handle.get_webview_window("main") {
                         let _ = window.show();

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1070,20 +1070,18 @@ pub fn run() {
         ])
         .build(tauri::generate_context!())
         .expect("error while building Better Email")
-        .run(move |_app_handle, event| {
-            match event {
-                #[cfg(target_os = "macos")]
-                tauri::RunEvent::Reopen { .. } => {
-                    if let Some(window) = _app_handle.get_webview_window("main") {
-                        let _ = window.show();
-                        let _ = window.unminimize();
-                        let _ = window.set_focus();
-                    }
+        .run(move |_app_handle, event| match event {
+            #[cfg(target_os = "macos")]
+            tauri::RunEvent::Reopen { .. } => {
+                if let Some(window) = _app_handle.get_webview_window("main") {
+                    let _ = window.show();
+                    let _ = window.unminimize();
+                    let _ = window.set_focus();
                 }
-                tauri::RunEvent::Exit | tauri::RunEvent::ExitRequested { .. } => {
-                    exit_startup.shutdown();
-                }
-                _ => {}
             }
+            tauri::RunEvent::Exit | tauri::RunEvent::ExitRequested { .. } => {
+                exit_startup.shutdown();
+            }
+            _ => {}
         });
 }

--- a/src/components/composer/composer.css
+++ b/src/components/composer/composer.css
@@ -1206,14 +1206,18 @@
 .custom-select-dropdown[data-portal-owner="composer-sender"] button:hover,
 .custom-select-dropdown[data-portal-owner="composer-sender"] button.active {
   color: var(--ui-text);
-  background: var(--ui-accent-soft);
+  background: var(--quiet-row-hover);
 }
 
-.custom-select-dropdown[data-portal-owner="composer-sender"] button[aria-selected="true"],
+.custom-select-dropdown[data-portal-owner="composer-sender"] button[aria-selected="true"] {
+  color: var(--ui-text);
+  background: transparent;
+}
+
 .custom-select-dropdown[data-portal-owner="composer-sender"] button[aria-selected="true"]:hover,
 .custom-select-dropdown[data-portal-owner="composer-sender"] button[aria-selected="true"].active {
-  color: var(--ui-accent);
-  background: var(--ui-accent-soft);
+  color: var(--ui-text);
+  background: var(--quiet-row-hover);
 }
 
 .custom-select-dropdown[data-portal-owner="composer-sender"] button > svg {

--- a/src/components/context-menu.css
+++ b/src/components/context-menu.css
@@ -14,9 +14,9 @@
   max-height: var(--context-menu-max-height, min(460px, calc(100vh - 16px)));
   overflow-y: auto;
   overflow-x: visible;
-  padding: var(--ui-menu-padding);
-  border: 1px solid var(--ui-border-strong);
-  border-radius: var(--ui-radius-panel);
+  padding: 4px;
+  border: 1px solid var(--ui-border);
+  border-radius: 12px;
   color: var(--ui-text);
   background: var(--ui-surface);
   box-shadow: var(--ui-shadow-popover);
@@ -35,9 +35,9 @@
   display: block;
   width: min(var(--ui-menu-width), calc(100vw - 16px));
   min-width: 0;
-  padding: var(--ui-menu-padding);
-  border: 1px solid var(--ui-border-strong);
-  border-radius: var(--ui-radius-panel);
+  padding: 4px;
+  border: 1px solid var(--ui-border);
+  border-radius: 12px;
   background: var(--ui-surface);
   box-shadow: var(--ui-shadow-popover);
 }
@@ -84,7 +84,7 @@
   gap: 8px;
   padding: 0 var(--ui-menu-item-padding-inline);
   border: 0;
-  border-radius: var(--ui-menu-item-radius);
+  border-radius: 8px;
   color: var(--ui-text);
   background: transparent;
   box-shadow: var(--ui-box-shadow-none);
@@ -114,9 +114,9 @@
   background: var(--ui-control-hover);
 }
 
+.context-menu-surface button:focus,
 .context-menu-surface button:focus-visible {
-  outline: var(--ui-focus-outline);
-  outline-offset: -1px;
+  outline: none;
 }
 
 .context-menu-surface button:disabled {
@@ -232,9 +232,9 @@
   max-height: min(var(--context-submenu-max-height, 360px), calc(100vh - 16px));
   display: none;
   overflow: auto;
-  padding: var(--ui-menu-padding);
-  border: 1px solid var(--ui-border-strong);
-  border-radius: var(--ui-radius-panel);
+  padding: 4px;
+  border: 1px solid var(--ui-border);
+  border-radius: 12px;
   background: var(--ui-surface);
   box-shadow: var(--ui-shadow-popover);
   z-index: 1;

--- a/src/hooks/useDetailsMenu.ts
+++ b/src/hooks/useDetailsMenu.ts
@@ -74,6 +74,19 @@ function hideFromTopLayer(panel: PopoverPanel | null) {
  * - 需要连续选择/编辑的菜单（如标签菜单）不调用 closeMenu，但仍受外部点击与
  *   Escape 关闭约束。
  */
+function clearPanelFloatingStyles(panel: HTMLElement | null) {
+  if (!panel) return;
+  panel.style.removeProperty('position');
+  panel.style.removeProperty('inset');
+  panel.style.removeProperty('top');
+  panel.style.removeProperty('left');
+  panel.style.removeProperty('right');
+  panel.style.removeProperty('bottom');
+  panel.style.removeProperty('margin');
+  panel.style.removeProperty('height');
+  panel.style.removeProperty('max-height');
+}
+
 export function useDetailsMenu(
   ref: RefObject<HTMLElement>,
   { floating = false, align = 'end' }: UseDetailsMenuOptions = {},
@@ -81,7 +94,9 @@ export function useDetailsMenu(
   const closeMenu = useCallback(() => {
     const details = ref.current;
     if (!details) return;
-    hideFromTopLayer(getFloatingPanel(details));
+    const panel = getFloatingPanel(details);
+    hideFromTopLayer(panel);
+    clearPanelFloatingStyles(panel);
     if (details.hasAttribute('open')) {
       details.removeAttribute('open');
     }
@@ -113,8 +128,14 @@ export function useDetailsMenu(
 
       // A native popover participates in the browser top layer, so pane
       // containment, overflow clipping and local stacking contexts cannot
-      // cover it. Hosts without the Popover API keep using the existing
-      // fixed-position path below.
+      // cover it. Set explicit sizing properties to avoid user-agent inset:0 stretching.
+      panel.style.setProperty('position', 'fixed');
+      panel.style.setProperty('inset', 'unset');
+      panel.style.setProperty('bottom', 'auto');
+      panel.style.setProperty('right', 'auto');
+      panel.style.setProperty('margin', '0');
+      panel.style.setProperty('height', 'max-content');
+
       showInTopLayer(panel);
 
       const summaryRect = summary.getBoundingClientRect();
@@ -142,6 +163,10 @@ export function useDetailsMenu(
         ? summaryRect.bottom + ANCHOR_GAP
         : Math.max(VIEWPORT_GAP, summaryRect.top - ANCHOR_GAP - panelHeight);
 
+      panel.style.setProperty('left', `${Math.round(left)}px`);
+      panel.style.setProperty('top', `${Math.round(top)}px`);
+      panel.style.setProperty('max-height', `${Math.floor(availableHeight)}px`);
+
       menu.style.setProperty('--floating-menu-left', `${Math.round(left)}px`);
       menu.style.setProperty('--floating-menu-top', `${Math.round(top)}px`);
       menu.style.setProperty('--floating-menu-max-height', `${Math.floor(availableHeight)}px`);
@@ -163,7 +188,9 @@ export function useDetailsMenu(
       if (!menu.hasAttribute('open')) {
         clearPositionFrame();
         menu.removeAttribute('data-menu-positioned');
-        hideFromTopLayer(getFloatingPanel(menu));
+        const panel = getFloatingPanel(menu);
+        hideFromTopLayer(panel);
+        clearPanelFloatingStyles(panel);
         return;
       }
       scheduleFloatingPosition();

--- a/src/styles/dropdowns.css
+++ b/src/styles/dropdowns.css
@@ -102,16 +102,18 @@
   /* CustomSelect supplies the final layer inline for modal callers. */
   z-index: 1000;
   display: grid;
+  align-content: start;
   gap: 2px;
   width: max-content;
-  min-width: 0;
+  min-width: 140px;
   max-width: min(var(--ui-dropdown-max-width), calc(100vw - 24px));
   max-height: min(280px, calc(100vh - 24px));
-  padding: var(--ui-menu-padding);
+  height: max-content;
+  padding: 4px;
   overflow-x: hidden;
   overflow-y: auto;
-  border: 1px solid var(--ui-border-strong);
-  border-radius: var(--ui-radius-panel);
+  border: 1px solid var(--ui-border);
+  border-radius: 12px;
   background: var(--ui-surface);
   color: var(--ui-text);
   box-shadow: var(--ui-shadow-popover);
@@ -143,7 +145,7 @@
   gap: 8px;
   padding: 6px 10px;
   border: 1px solid transparent;
-  border-radius: var(--ui-menu-item-radius);
+  border-radius: 8px;
   color: var(--ui-text);
   background: transparent;
   box-shadow: var(--ui-box-shadow-none);
@@ -194,11 +196,20 @@
   background: var(--surface-active);
 }
 
-.custom-select-dropdown button[aria-selected="true"],
-.custom-select-dropdown button[aria-selected="true"]:hover,
-.custom-select-dropdown button[aria-selected="true"].active {
+.custom-select-dropdown button[aria-selected="true"] {
+  color: var(--ui-text);
+  background: transparent;
+}
+
+.custom-select-dropdown button[aria-selected="true"] > svg {
   color: var(--ui-accent);
-  background: var(--ui-accent-soft);
+}
+
+.custom-select-dropdown button[aria-selected="true"]:hover,
+.custom-select-dropdown button[aria-selected="true"]:focus-visible,
+.custom-select-dropdown button[aria-selected="true"].active {
+  color: var(--ui-text);
+  background: var(--quiet-row-hover);
 }
 
 .custom-select-dropdown button:disabled {

--- a/src/styles/message-list.css
+++ b/src/styles/message-list.css
@@ -622,25 +622,30 @@
   right: 0;
   left: auto;
   z-index: 80;
-  display: grid;
-  gap: 1px;
-  min-width: max-content;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 140px;
+  width: max-content;
   max-width: min(92vw, 320px);
   max-height: 320px;
-  padding: var(--ui-menu-padding);
+  height: max-content;
+  padding: 4px;
   overflow-x: hidden;
   overflow-y: auto;
-  border: 1px solid var(--ui-border-strong);
+  border: 1px solid var(--ui-border);
   border-radius: var(--ui-radius-panel);
   background: var(--ui-surface);
   box-shadow: var(--ui-shadow-popover);
 }
 
 .compact-menu > div button {
-  min-height: var(--ui-menu-item-height);
-  padding: 0 var(--ui-menu-item-padding-inline);
+  width: 100%;
+  min-height: 32px;
+  height: 32px;
+  padding: 0 10px;
   border: 0;
-  border-radius: var(--ui-menu-item-radius);
+  border-radius: var(--ui-radius-sm);
   color: var(--ui-text);
   background: transparent;
   box-shadow: var(--ui-box-shadow-none);
@@ -651,6 +656,8 @@
   align-items: center;
   gap: 7px;
   cursor: pointer;
+  white-space: nowrap;
+  transition: var(--ui-transition-fast-color-background);
 }
 
 .compact-menu > div button:hover,
@@ -660,11 +667,16 @@
 }
 
 .compact-menu > div button:focus-visible {
-  box-shadow: inset 0 0 0 1px var(--color-focus);
+  box-shadow: none;
 }
 
 .compact-menu > div button.active {
-  background: var(--quiet-row-selected);
+  background: transparent;
+}
+
+.compact-menu > div button.active:hover,
+.compact-menu > div button.active:focus-visible {
+  background: var(--quiet-row-hover);
 }
 
 .compact-menu > div button:disabled {
@@ -2215,12 +2227,14 @@
   left: 0;
   z-index: 2500;
   width: max-content;
-  min-width: 0;
+  min-width: 140px;
   max-width: min(var(--ui-dropdown-max-width), calc(100vw - 24px));
-  padding: var(--ui-menu-padding);
-  display: grid;
-  gap: 1px;
-  border: 1px solid var(--ui-border-strong);
+  height: max-content;
+  padding: 4px;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  border: 1px solid var(--ui-border);
   border-radius: var(--ui-radius-panel);
   background: var(--ui-surface);
   box-shadow: var(--ui-shadow-popover);
@@ -2232,13 +2246,15 @@
 }
 
 .compact-dropdown > div button {
-  min-height: var(--ui-menu-item-height);
-  padding: 0 var(--ui-menu-item-padding-inline);
+  width: 100%;
+  min-height: 32px;
+  height: 32px;
+  padding: 0 10px;
   display: flex;
   align-items: center;
   gap: 6px;
   border: 0;
-  border-radius: var(--ui-menu-item-radius);
+  border-radius: var(--ui-radius-sm);
   color: var(--ui-text);
   background: transparent;
   box-shadow: var(--ui-box-shadow-none);
@@ -2246,6 +2262,7 @@
   font-weight: 500;
   text-align: left;
   white-space: nowrap;
+  transition: var(--ui-transition-fast-color-background);
 }
 
 .compact-dropdown > div button:hover,
@@ -2256,12 +2273,18 @@
 }
 
 .compact-dropdown > div button.active {
-  color: var(--ui-accent);
-  background: var(--ui-accent-soft);
+  color: var(--ui-text);
+  background: transparent;
+  font-weight: 500;
+}
+
+.compact-dropdown > div button.active:hover,
+.compact-dropdown > div button.active:focus-visible {
+  background: var(--quiet-row-hover);
 }
 
 .compact-dropdown > div button:focus-visible {
-  box-shadow: var(--ui-focus-ring);
+  box-shadow: none;
 }
 
 .compact-dropdown-check {

--- a/src/styles/popovers.css
+++ b/src/styles/popovers.css
@@ -14,15 +14,22 @@
   contain: none;
 }
 
-details[data-floating-menu="true"].compact-menu[open] > div,
-details[data-floating-menu="true"].compact-dropdown[open] > div {
+details[data-floating-menu="true"][open] > :is([data-floating-menu-panel="true"], div),
+details[data-floating-menu="true"] > :is([data-floating-menu-panel="true"], div):popover-open {
   box-sizing: border-box;
   position: fixed;
+  inset: unset;
+  inset-block: unset;
+  inset-inline: unset;
   top: var(--floating-menu-top, 0);
+  left: var(--floating-menu-left, 0);
   right: auto;
   bottom: auto;
-  left: var(--floating-menu-left, 0);
+  margin: 0;
   z-index: 2500;
+  width: max-content;
+  min-width: 140px;
+  height: max-content;
   max-width: calc(100vw - 16px);
   max-height: min(460px, var(--floating-menu-max-height, calc(100dvh - 16px)));
   overflow-x: hidden;
@@ -32,15 +39,18 @@ details[data-floating-menu="true"].compact-dropdown[open] > div {
 }
 
 /* Native popovers are promoted into the browser top layer. Reset the user
- * agent's centering margin so the shared viewport coordinates stay exact.
+ * agent's centering margin and default inset so shared viewport coordinates stay exact.
  * The details/fixed-position rules above remain the compatibility fallback
  * for older WebViews without the Popover API. */
 details[data-floating-menu="true"] > [data-floating-menu-panel="true"] {
   margin: 0;
+  inset: unset;
+  bottom: auto;
+  right: auto;
+  height: max-content;
 }
 
-details[data-floating-menu="true"][data-menu-positioned="true"].compact-menu > div,
-details[data-floating-menu="true"][data-menu-positioned="true"].compact-dropdown > div {
+details[data-floating-menu="true"][data-menu-positioned="true"] > :is([data-floating-menu-panel="true"], div) {
   visibility: visible;
 }
 


### PR DESCRIPTION
## 修复内容

1. **修复全局下拉弹窗纵向拉伸变形的底层问题**
   - 修复浏览器内置 Top Layer Popover API（WebKit/Blink）在 `:popover-open` 时的默认样式 `inset: 0` 导致弹窗向下强制撑满整个视口视窗的几何错误。
   - 在 `src/hooks/useDetailsMenu.ts` 测量前主动清空 `inset: unset`，并在测量定位时将 `panel` 的 `inset: unset; bottom: auto; height: max-content` 写死，彻底杜绝元素测量出全屏高度。
   - 在 `src/styles/popovers.css` 中为所有浮动弹窗重设 `inset: unset`、`bottom: auto` 与 `height: max-content`，覆盖所有使用浮动面板的组件（不仅限于 compact 菜单）。

2. **重构列表筛选与排序下拉弹窗（去 AI 粗笨感，轻盈原生化）**
   - 在 `src/styles/message-list.css` 中将 `.compact-dropdown > div` 与 `.compact-menu > div` 的容器布局由 `display: grid` 重构为 `display: flex; flex-direction: column`，杜绝 Grid 自动拉伸轨道导致各行按钮高度膨胀为 80px 的怪异表现。
   - 增加标准最小宽度 `min-width: 140px`，告别选项文字短时 80px 宽的牙签状细柱。
   - 移除被选中项（如“全部”、“最新优先”）上粗笨刺眼的淡绿色整块实色背景（`var(--ui-accent-soft)`），恢复为自然透明底色配合克制绿色对勾 `Check` 图标，鼠标悬停时平滑触发 `var(--quiet-row-hover)`。

3. **全局弹窗圆润化（border-radius 12px / 8px）与去刺眼轮廓**
   - 全局弹窗外框采用一致的 `border-radius: 12px`，各子项采用 `border-radius: 8px`。
   - 移除上下文菜单在聚焦时的 2px 绿色刺眼边框，统一为原生平滑的静音悬停背景。
   - 同步优化 `CustomSelect` 下拉菜单的选中项视觉与圆角。

4. **修复 macOS 下关闭窗口后点击 Dock 图标无法唤起窗口的问题**
   - 在 `src-tauri/src/lib.rs` 的 `app.run()` 中监听 `tauri::RunEvent::Reopen` 事件。
   - 当主窗口被关闭（隐藏）或最小化后，用户在 macOS 底部 Dock 栏点击应用图标时，自动调用 `window.show()`、`window.unminimize()` 与 `window.set_focus()`，保证窗口能够重新激活展示，无需通过右键托盘唤起。