### PR TITLE
fix: 恢复移动端头像、阅读布局与底部导航

### DIFF
--- a/src/components/mobile/MobileBottomNav.test.tsx
+++ b/src/components/mobile/MobileBottomNav.test.tsx
@@ -1,0 +1,46 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import MobileBottomNav from './MobileBottomNav';
+
+function renderNav(filter: 'all' | 'starred' = 'all') {
+  const handlers = {
+    onOpenMail: vi.fn(),
+    onOpenStarred: vi.fn(),
+    onCompose: vi.fn(),
+    onOpenSettings: vi.fn(),
+  };
+  const view = render(<MobileBottomNav filter={filter} {...handlers} />);
+  return { ...handlers, ...view };
+}
+
+describe('MobileBottomNav', () => {
+  it('keeps all four primary mobile actions reachable', () => {
+    const handlers = renderNav();
+
+    const mail = screen.getByRole('button', { name: '邮件' });
+    const starred = screen.getByRole('button', { name: '星标' });
+    const compose = screen.getByRole('button', { name: '写邮件' });
+    const settings = screen.getByRole('button', { name: '设置' });
+
+    expect(screen.getByRole('navigation', { name: '主导航' })).toBeInTheDocument();
+    expect(mail).toHaveAttribute('aria-current', 'page');
+    expect(starred).not.toHaveAttribute('aria-current');
+
+    fireEvent.click(mail);
+    fireEvent.click(starred);
+    fireEvent.click(compose);
+    fireEvent.click(settings);
+
+    expect(handlers.onOpenMail).toHaveBeenCalledTimes(1);
+    expect(handlers.onOpenStarred).toHaveBeenCalledTimes(1);
+    expect(handlers.onCompose).toHaveBeenCalledTimes(1);
+    expect(handlers.onOpenSettings).toHaveBeenCalledTimes(1);
+  });
+
+  it('marks starred as the active destination when the starred filter is open', () => {
+    renderNav('starred');
+
+    expect(screen.getByRole('button', { name: '邮件' })).not.toHaveAttribute('aria-current');
+    expect(screen.getByRole('button', { name: '星标' })).toHaveAttribute('aria-current', 'page');
+  });
+});

--- a/src/components/mobile/MobileBottomNav.tsx
+++ b/src/components/mobile/MobileBottomNav.tsx
@@ -1,4 +1,9 @@
-import { PenLine } from 'lucide-react';
+import {
+  Mail,
+  PenLine,
+  Settings,
+  Star,
+} from 'lucide-react';
 import type { FilterMode } from '../../app/types';
 
 type MobileBottomNavProps = {
@@ -9,23 +14,44 @@ type MobileBottomNavProps = {
   onOpenSettings: () => void;
 };
 
-/**
- * Mobile mail no longer has a generic four-tab bottom navigation. Mail and
- * starred are states of the inbox, settings lives in mailbox navigation, and
- * compose is the only global action that benefits from persistent reachability.
- *
- * Keep the legacy callback shape for App-level compatibility while the shell
- * owns the migration; only onCompose is rendered here.
- */
-export default function MobileBottomNav({ onCompose }: MobileBottomNavProps) {
+/** Persistent mobile navigation keeps the app's primary destinations reachable. */
+export default function MobileBottomNav({
+  filter,
+  onOpenMail,
+  onOpenStarred,
+  onCompose,
+  onOpenSettings,
+}: MobileBottomNavProps) {
   return (
-    <div className="mobile-bottom-nav" role="group" aria-label="邮件快捷操作">
+    <nav className="mobile-bottom-nav" aria-label="主导航">
+      <button
+        type="button"
+        className={filter !== 'starred' ? 'active' : ''}
+        aria-current={filter !== 'starred' ? 'page' : undefined}
+        onClick={onOpenMail}
+      >
+        <Mail size={21} aria-hidden="true" />
+        <span>邮件</span>
+      </button>
+      <button
+        type="button"
+        className={filter === 'starred' ? 'active' : ''}
+        aria-current={filter === 'starred' ? 'page' : undefined}
+        onClick={onOpenStarred}
+      >
+        <Star size={21} fill={filter === 'starred' ? 'currentColor' : 'none'} aria-hidden="true" />
+        <span>星标</span>
+      </button>
       <button type="button" className="mobile-bottom-compose" aria-label="写邮件" onClick={onCompose}>
         <span className="mobile-bottom-compose-icon">
           <PenLine size={22} aria-hidden="true" />
         </span>
         <span>写邮件</span>
       </button>
-    </div>
+      <button type="button" onClick={onOpenSettings}>
+        <Settings size={21} aria-hidden="true" />
+        <span>设置</span>
+      </button>
+    </nav>
   );
 }

--- a/src/styles/mobile-shell-contract.css
+++ b/src/styles/mobile-shell-contract.css
@@ -1,0 +1,132 @@
+/*
+ * Mobile shell contracts that must remain stable even when product-level
+ * density/polish rules change. These rules intentionally load after
+ * product.css so navigation, sender identity and reader reachability cannot
+ * be removed by visual-only refinements.
+ */
+@media (max-width: 720px) {
+  /* Keep sender identity visible in the mobile message list. */
+  .app-shell.is-mobile-app .mobile-message-list-panel .message-card {
+    padding: 8px 58px 8px 64px;
+  }
+
+  .app-shell.is-mobile-app .mobile-message-list-panel .message-leading {
+    display: block;
+  }
+
+  /* The persistent bottom navigation is a primary app control, not a FAB. */
+  .app-shell.is-mobile-app .mobile-bottom-nav {
+    position: relative;
+    inset: auto;
+    z-index: 30;
+    width: 100%;
+    height: auto;
+    min-height: calc(64px + env(safe-area-inset-bottom));
+    flex: 0 0 calc(64px + env(safe-area-inset-bottom));
+    display: grid;
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+    align-items: start;
+    padding: 5px 8px env(safe-area-inset-bottom);
+    border: 0;
+    border-top: 1px solid var(--ui-border);
+    background: var(--ui-surface);
+    pointer-events: auto;
+  }
+
+  .app-shell.is-mobile-app .mobile-bottom-nav > button {
+    position: static;
+    width: auto;
+    min-width: 0;
+    height: auto;
+    min-height: 54px;
+    display: flex;
+    align-items: center;
+    justify-content: flex-start;
+    flex-direction: column;
+    gap: 3px;
+    padding: 4px 2px 0;
+    border: 0;
+    border-radius: 0;
+    color: var(--ui-text-tertiary);
+    background: transparent;
+    box-shadow: none;
+    font-size: 11.5px;
+    font-weight: 600;
+    white-space: nowrap;
+    pointer-events: auto;
+  }
+
+  .app-shell.is-mobile-app .mobile-bottom-nav > button.active {
+    color: var(--ui-accent);
+  }
+
+  .app-shell.is-mobile-app .mobile-bottom-nav > .mobile-bottom-compose {
+    right: auto;
+    bottom: auto;
+    z-index: auto;
+    width: auto;
+    min-width: 0;
+    height: auto;
+    min-height: 54px;
+    display: flex;
+    padding: 4px 2px 0;
+    border: 0;
+    border-radius: 0;
+    color: var(--ui-accent) !important;
+    background: transparent;
+    box-shadow: none;
+    transform: none;
+  }
+
+  .app-shell.is-mobile-app .mobile-bottom-compose-icon {
+    width: 44px;
+    height: 36px;
+    display: grid;
+    place-items: center;
+    border-radius: var(--ui-radius-control);
+    color: var(--color-text-on-accent);
+    background: var(--ui-accent);
+  }
+
+  .app-shell.is-mobile-app .mobile-bottom-compose > span:last-child {
+    display: inline;
+  }
+
+  .app-shell.is-mobile-app .mobile-message-list-panel :is(.message-list, .thread-list) {
+    padding-bottom: 8px;
+  }
+
+  /* Constrain the reader chrome to the viewport while keeping oversized HTML
+     email content horizontally reachable inside its own scroll surface. */
+  .app-shell.is-mobile-app .mobile-reader-surface,
+  .app-shell.is-mobile-app .mobile-reader-surface > .reader-panel,
+  .app-shell.is-mobile-app .mobile-reader-surface .reader,
+  .app-shell.is-mobile-app .mobile-reader-surface .reader-header,
+  .app-shell.is-mobile-app .mobile-reader-surface .reader-html-container,
+  .app-shell.is-mobile-app .mobile-reader-surface .reader-html {
+    width: 100%;
+    max-width: 100%;
+    min-width: 0;
+  }
+
+  .app-shell.is-mobile-app .mobile-reader-surface > .reader-panel {
+    overflow-x: hidden;
+    overflow-y: auto;
+    touch-action: pan-x pan-y;
+  }
+
+  .app-shell.is-mobile-app .mobile-reader-surface .reader-actions {
+    width: 100%;
+    max-width: 100%;
+    margin-inline: 0;
+    padding: 4px 0;
+  }
+
+  .app-shell.is-mobile-app .mobile-reader-surface .reader-html-container {
+    overflow-x: auto;
+    overflow-y: visible;
+    overscroll-behavior-x: contain;
+    -webkit-overflow-scrolling: touch;
+    touch-action: pan-x pan-y;
+  }
+}

--- a/src/ui-2026.css
+++ b/src/ui-2026.css
@@ -36,3 +36,6 @@
 
 /* Consolidated product hierarchy; new features belong to their component styles. */
 @import './styles/product.css';
+
+/* Mobile navigation/identity/reader behavior is a shell contract, not polish. */
+@import './styles/mobile-shell-contract.css';


### PR DESCRIPTION
## 修复内容
- 恢复邮件列表发件人头像，撤销移动端 `message-leading` 被隐藏的视觉回归
- 恢复主界面底部四项导航：邮件 / 星标 / 写邮件 / 设置
- 修复阅读页横向裁切：阅读器 chrome 固定在视口内，超宽 HTML 邮件内容可横向访问
- 将上述行为固化为 mobile shell contract，并放在 product polish 之后，避免再次被纯视觉样式覆盖
- 新增 MobileBottomNav 回归测试，覆盖四个入口和活动状态

## 根因
- `583e071` 将四栏底部导航重构成仅保留写邮件入口
- `product.css` 后置规则隐藏了移动端 `.message-leading`，并把底栏压缩为 FAB
- 阅读器存在超宽 HTML 内容时，外层裁切/触摸方向约束会导致左右内容不可达

## 验证
- 分支相对 main 仅涉及移动端导航、样式契约和对应测试
- 等待 GitHub Actions 完成后合并